### PR TITLE
API returns 'United States' not 'US'

### DIFF
--- a/spec/lob/v1/address_spec.rb
+++ b/spec/lob/v1/address_spec.rb
@@ -38,7 +38,7 @@ describe Lob::V1::Address do
             zip:   sample_params2[:zip]
           )
 
-          result["address"]["address_country"].must_equal("US")
+          result["address"]["address_country"].must_equal("United States")
         end
       end
     end
@@ -52,7 +52,7 @@ describe Lob::V1::Address do
           zip:   sample_params[:zip]
         )
 
-        result["address"]["address_country"].must_equal("US")
+        result["address"]["address_country"].must_equal("United States")
       end
     end
   end


### PR DESCRIPTION
Simple fix for the [current build fail](https://travis-ci.org/lob/lob-ruby/jobs/15788917).

It's because the api seems to return the full country name rather than the country code.

All the tests are passing now!
