### PR TITLE
lob-ruby should not callout to rubygems to get the version number.

### DIFF
--- a/lib/lob.rb
+++ b/lib/lob.rb
@@ -1,6 +1,7 @@
 require "rest-client"
 require "json"
 require "lob/lob_error"
+require "lob/version"
 
 # Dynamically require files
 Dir[File.join(File.dirname(__FILE__), 'lob', 'v*', '*.rb')].each {|file| require file }
@@ -28,7 +29,7 @@ module Lob
 
 
   def self.submit(method, url, parameters={})
-    clientVersion = Gem.latest_spec_for('lob').version.to_s
+    clientVersion = Lob::VERSION
 
     if method == :get || method == :delete
       JSON(RestClient.send(method, url, {

--- a/lib/lob/version.rb
+++ b/lib/lob/version.rb
@@ -1,0 +1,3 @@
+module Lob
+  VERSION = "1.7"
+end

--- a/lob.gemspec
+++ b/lob.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
+require File.expand_path('../lib/lob/version', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-
 
 Gem::Specification.new do |spec|
   spec.name          = "lob"
-  spec.version       = "1.7"
+  spec.version       = Lob::VERSION
   spec.authors       = ["Lob"]
   spec.email         = ["support@lob.com"]
   spec.description   = %q{Lob API Ruby wrapper}


### PR DESCRIPTION
 The gem should know it's own version number through a version file.
