### PR TITLE
fix(prawn): default to prawn 1.3.0 for support for Ruby 1.9.3

### DIFF
--- a/lob.gemspec
+++ b/lob.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rest-client", "~> 1.7.0"
 
-  spec.add_dependency "prawn", ">= 0"
+  spec.add_dependency "prawn", "~> 1.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.3.2"


### PR DESCRIPTION
Should fix the errors we are seeing in the 1.9.3 and jruby builds.