### PR TITLE
Reduce strictness of rest-client version specification

### DIFF
--- a/lob.gemspec
+++ b/lob.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client", "~> 1.7.0"
+  spec.add_dependency "rest-client", "~> 1.7"
 
   spec.add_dependency "prawn", "~> 1.3.0"
 


### PR DESCRIPTION
Allow integrators to use `rest-client` 1.8.0+, which fixes [this vulnerability](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rest-client/CVE-2015-1820.yml)

`rest-client` is semantically versioned, so it's only the major version you need to pin to.