### PR TITLE
Break dependency on Rack by implementing build_nested_query

### DIFF
--- a/lob.gemspec
+++ b/lob.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rest-client", "~> 1.8"
-  spec.add_dependency "rack", "~> 1.6"
 
   spec.add_dependency "prawn"
 


### PR DESCRIPTION
We ran into problems integrating 1.12.0 version of the Lob gem with our Rails 4.1.10 app to the tune of:

```
Bundler could not find compatible versions for gem "rack":
  In Gemfile:
    rails (~> 4.1.10) ruby depends on
      actionpack (= 4.1.10) ruby depends on
        rack (~> 1.5.2) ruby

    lob (~> 1.12.0) ruby depends on
      rack (1.6.0)
```

While upgrading to Rails 4.2 is on our roadmap, we saw that the Lob gem only depends on Rack to use its `build_nested_query` utility, so we took the liberty of excising that method from Rack and adding it to the gem. Happy to reorganize the code if there's a better spot for this method.