### PR TITLE
Protect against KeyError in error handling method

### DIFF
--- a/lib/lob.rb
+++ b/lib/lob.rb
@@ -55,9 +55,9 @@ module Lob
   def self.handle_api_error(error)
     begin
       response = JSON.parse(error.http_body)
-      message = response["error"]["message"]
+      message = response.fetch("error").fetch("message")
       raise InvalidRequestError.new(message, error.http_code, error.http_body, error.response)
-    rescue JSON::ParserError
+    rescue JSON::ParserError, KeyError
       raise LobError.new("Invalid response object: #{}", error.http_code, error.http_body)
     end
   end


### PR DESCRIPTION
Looks like we just received an error from you guys that could be parsed as JSON but didn't have an `error` key. As a result we saw `NoMethodError: undefined method [] for nil:NilClass`.

It's good practice to protect against all exceptions in an error handling method like `Lob.handle_api_error`.