### PR TITLE
Remove address reformatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,4 @@ env:
   JRUBY_OPTS=--2.0
   - LOB_API_KEY=test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc
 
-before_script:
-  - bundle exec rake dev:setup
-
 script: bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -180,10 +180,6 @@ Make sure you have Ruby 2.0 installed. Copy and paste the following commands in 
 
 ## Testing
 
-To run the tests, download the required sample files by running the following command:
-
-    bundle exec rake dev:setup
-
 Tests are written using MiniTest, a testing library that comes with Ruby stdlib.
 
 You'll need to pass in your Lob.com API as the environment variable `LOB_API_KEY`, to run the tests. Be sure to use your Test API key, and not the Live one.

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,8 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-
 Rake::TestTask.new do |t|
   t.libs.push "lib", "spec"
   t.test_files = FileList['spec/**/*_spec.rb']
   t.verbose = true
-end
-
-
-namespace :dev do
-
-  desc "Download sample files to run tests with"
-  task :setup do
-    Dir.mkdir("spec/samples") unless File.exist?("spec/samples")
-    files = [
-      {url: "https://lob.com/postcardfront.pdf",                               name: "postcardfront.pdf"},
-      {url: "https://lob.com/postcardback.pdf",                                name: "postcardback.pdf"},
-      {url: "https://s3-us-west-2.amazonaws.com/lob-assets/letter-goblue.pdf", name: "8.5x11.pdf"},
-    ]
-    files.each do |f|
-      system "curl #{f[:url]} -o spec/samples/#{f[:name]}"
-    end
-
-  end
 end

--- a/lib/lob.rb
+++ b/lib/lob.rb
@@ -19,12 +19,6 @@ module Lob
     alias :config :configure
   end
 
-  def self.require_options(options, *keys)
-    keys.each do |key|
-      raise ArgumentError.new(":#{key} is required") unless options.key?(key)
-    end
-  end
-
   def self.submit(method, url, parameters={})
     clientVersion = Lob::VERSION
 

--- a/lib/lob/v1/address.rb
+++ b/lib/lob/v1/address.rb
@@ -7,8 +7,7 @@ module Lob
       end
 
       def verify(options={})
-        params = @resource.format_address_params(options, false)
-        Lob.submit(:post, address_verify_url, params)
+        Lob.submit(:post, address_verify_url, options)
       end
 
       def list(options={})
@@ -20,7 +19,7 @@ module Lob
       end
 
       def create(options = {})
-        Lob.submit :post, address_url, @resource.format_address_params(options)
+        Lob.submit :post, address_url, options
       end
 
       def destroy(address_id)

--- a/lib/lob/v1/bank_account.rb
+++ b/lib/lob/v1/bank_account.rb
@@ -15,14 +15,6 @@ module Lob
       end
 
       def create(options = {})
-        if !options[:bank_address].is_a?(String)
-          options[:bank_address] = @resource.format_address_params(options[:bank_address])
-        end
-
-        if !options[:account_address].is_a?(String)
-          options[:account_address] = @resource.format_address_params(options[:account_address])
-        end
-
         Lob.submit :post, bank_account_url, options
       end
 

--- a/lib/lob/v1/check.rb
+++ b/lib/lob/v1/check.rb
@@ -15,10 +15,6 @@ module Lob
       end
 
       def create(options = {})
-        if !options[:to].is_a?(String)
-          options[:to] = @resource.format_address_params(options[:to])
-        end
-
         Lob.submit :post, check_url, options
       end
 

--- a/lib/lob/v1/job.rb
+++ b/lib/lob/v1/job.rb
@@ -24,14 +24,6 @@ module Lob
         end
         options.delete(:objects)
 
-        if options[:to] && !options[:to].is_a?(String)
-          options[:to] = @resource.format_address_params(options[:to])
-        end
-
-        if options[:from] && !options[:from].is_a?(String)
-          options[:from] = @resource.format_address_params(options[:from])
-        end
-
         Lob.submit :post, job_url, options
       end
 

--- a/lib/lob/v1/letter.rb
+++ b/lib/lob/v1/letter.rb
@@ -15,18 +15,8 @@ module Lob
       end
 
       def create(options = {})
-
-        if options[:to] && !options[:to].is_a?(String)
-          options[:to] = @resource.format_address_params(options[:to])
-        end
-
-        if options[:from] && !options[:from].is_a?(String)
-          options[:from] = @resource.format_address_params(options[:from])
-        end
-
         Lob.submit :post, letter_url, options
       end
-
 
       private
 

--- a/lib/lob/v1/postcard.rb
+++ b/lib/lob/v1/postcard.rb
@@ -15,14 +15,6 @@ module Lob
       end
 
       def create(options = {})
-        if options[:to] && !options[:to].is_a?(String)
-          options[:to] = @resource.format_address_params(options[:to])
-        end
-
-        if options[:from] && !options[:from].is_a?(String)
-          options[:from] = @resource.format_address_params(options[:from])
-        end
-
         Lob.submit :post, postcard_url, options
       end
 

--- a/lib/lob/v1/resource.rb
+++ b/lib/lob/v1/resource.rb
@@ -72,22 +72,6 @@ module Lob
         "#{base_url}/#{resource_type}#{'/' + resource_id if resource_id}"
       end
 
-      #NOTE to format address param names into API-compatible ones
-      def format_address_params(params, check_required_options=true)
-        if check_required_options
-          Lob.require_options(params, :name, :address_line1, :city, :state, :zip, :country)
-        end
-
-        new_params = params.clone
-
-        [:city, :state, :zip, :country].each do |option|
-          new_params["address_#{option}".to_sym] = params[option] if params[option]
-          new_params.delete(option)
-        end
-
-        new_params
-      end
-
     end
   end
 end

--- a/spec/lob/v1/address_spec.rb
+++ b/spec/lob/v1/address_spec.rb
@@ -6,10 +6,10 @@ describe Lob::V1::Address do
     {
       name: "John Doe",
       address_line1: "325 Berry Street",
-      city: "San Francisco",
-      state: "CA",
-      country: "US",
-      zip: 94158
+      address_city: "San Francisco",
+      address_state: "CA",
+      address_country: "US",
+      address_zip: 94158
     }
   }
 
@@ -20,9 +20,9 @@ describe Lob::V1::Address do
     it "should verify an address" do
       result = subject.addresses.verify(
         address_line1: sample_params[:address_line1],
-        city:  sample_params[:city],
-        state: sample_params[:state],
-        zip:   sample_params[:zip]
+        address_city:  sample_params[:address_city],
+        address_state: sample_params[:address_state],
+        address_zip:   sample_params[:address_zip]
       )
 
       result["address"]["address_country"].must_equal("US")

--- a/spec/lob/v1/bank_account_spec.rb
+++ b/spec/lob/v1/bank_account_spec.rb
@@ -9,10 +9,10 @@ describe Lob::V1::BankAccount do
       email:   "test@test.com",
       address_line1: "123 Test Street",
       address_line2: "Unit 199",
-      city:    "Mountain View",
-      state:   "CA",
-      country: "US",
-      zip:     94085
+      address_city:    "Mountain View",
+      address_state:   "CA",
+      address_country: "US",
+      address_zip:     94085
     }
 
     @sample_bank_account_params = {

--- a/spec/lob/v1/check_spec.rb
+++ b/spec/lob/v1/check_spec.rb
@@ -9,10 +9,10 @@ describe Lob::V1::Check do
       email:   "test@test.com",
       address_line1: "123 Test Street",
       address_line2: "Unit 199",
-      city:    "Mountain View",
-      state:   "CA",
-      country: "US",
-      zip:     94085
+      address_city:    "Mountain View",
+      address_state:   "CA",
+      address_country: "US",
+      address_zip:     94085
     }
 
     @sample_bank_account_params = {

--- a/spec/lob/v1/job_spec.rb
+++ b/spec/lob/v1/job_spec.rb
@@ -8,10 +8,10 @@ describe Lob::V1::Job do
       email:   "test@test.com",
       address_line1: "123 Test Street",
       address_line2: "Unit 199",
-      city:    "Mountain View",
-      state:   "CA",
-      country: "US",
-      zip:     94085
+      address_city:    "Mountain View",
+      address_state:   "CA",
+      address_country: "US",
+      address_zip:     94085
     }
 
     @sample_job_params    = { description: "TestJob" }

--- a/spec/lob/v1/letter_spec.rb
+++ b/spec/lob/v1/letter_spec.rb
@@ -8,10 +8,10 @@ describe Lob::V1::Letter do
       email:   "test@test.com",
       address_line1: "123 Test Street",
       address_line2: "Unit 199",
-      city:    "Mountain View",
-      state:   "CA",
-      country: "US",
-      zip:     94085
+      address_city:    "Mountain View",
+      address_state:   "CA",
+      address_country: "US",
+      address_zip:     94085
     }
   end
 

--- a/spec/lob/v1/postcard_spec.rb
+++ b/spec/lob/v1/postcard_spec.rb
@@ -8,10 +8,10 @@ describe Lob::V1::Postcard do
       email:   "test@test.com",
       address_line1: "123 Test Street",
       address_line2: "Unit 199",
-      city:    "Mountain View",
-      state:   "CA",
-      country: "US",
-      zip:     94085
+      address_city:    "Mountain View",
+      address_state:   "CA",
+      address_country: "US",
+      address_zip:     94085
     }
 
     @sample_postcard_params = {


### PR DESCRIPTION
@robinjoseph08 @elnaz @pon 

Using `city`, `state`, and `zip` instead of `address_city`, etc. was confusing people.