### PR TITLE
A small improvement in exception logging

### DIFF
--- a/lib/lob.rb
+++ b/lib/lob.rb
@@ -52,7 +52,7 @@ module Lob
       message = response.fetch("error").fetch("message")
       raise InvalidRequestError.new(message, error.http_code, error.http_body, error.response)
     rescue JSON::ParserError, KeyError
-      raise LobError.new("Invalid response object: #{}", error.http_code, error.http_body)
+      raise LobError.new("Invalid response object (#{error.http_code}): #{error.http_body}")
     end
   end
 

--- a/lib/lob.rb
+++ b/lib/lob.rb
@@ -52,7 +52,7 @@ module Lob
       message = response.fetch("error").fetch("message")
       raise InvalidRequestError.new(message, error.http_code, error.http_body, error.response)
     rescue JSON::ParserError, KeyError
-      raise LobError.new("Invalid response object (#{error.http_code}): #{error.http_body}")
+      raise LobError.new("Invalid response object:", error.http_code, error.http_body)
     end
   end
 

--- a/lib/lob/errors/lob_error.rb
+++ b/lib/lob/errors/lob_error.rb
@@ -6,12 +6,8 @@ module Lob
       @http_status = http_status
       @http_body = http_body
       @json_body = json_body
-      super(custom_message)
-    end
-
-    def custom_message
       status_string = @http_status.nil? ? "" : "(Status #{@http_status}) "
-      "#{status_string}#{to_s} \n #{@http_body}"
+      super("#{status_string}#{message} \n #{@http_body}")
     end
   end
 end

--- a/lib/lob/errors/lob_error.rb
+++ b/lib/lob/errors/lob_error.rb
@@ -1,17 +1,17 @@
 module Lob
   class LobError < StandardError
-    attr_reader :message, :http_status, :http_body, :json_body
+    attr_reader :http_status, :http_body, :json_body
 
-    def initialize(message=nil, http_status=nil, http_body=nil, json_body=nil)
-      @message = message
+    def initialize(message, http_status=nil, http_body=nil, json_body=nil)
       @http_status = http_status
       @http_body = http_body
       @json_body = json_body
+      super(custom_message)
     end
 
-    def to_s
+    def custom_message
       status_string = @http_status.nil? ? "" : "(Status #{@http_status}) "
-      "#{status_string}#{@message}"
+      "#{status_string}#{to_s} \n #{@http_body}"
     end
   end
 end

--- a/spec/lob/errors/lob_error_spec.rb
+++ b/spec/lob/errors/lob_error_spec.rb
@@ -5,11 +5,13 @@ describe Lob::LobError do
   describe "#to_s" do
     it "should return a string with the status code and message" do
       error = Lob::LobError.new("hello", 404)
-      error.to_s.must_include("(Status 404) hello")
+      error.to_s.must_include("(Status 404)")
+      error.to_s.must_include("hello")
     end
 
     it "should returna a message without the status code if not provided" do
       error = Lob::LobError.new("hello")
+      error.to_s.wont_include("Status")
       error.to_s.must_include("hello")
     end
   end

--- a/spec/lob/errors/lob_error_spec.rb
+++ b/spec/lob/errors/lob_error_spec.rb
@@ -5,12 +5,12 @@ describe Lob::LobError do
   describe "#to_s" do
     it "should return a string with the status code and message" do
       error = Lob::LobError.new("hello", 404)
-      error.to_s.must_equal("(Status 404) hello")
+      error.to_s.must_include("(Status 404) hello")
     end
 
     it "should returna a message without the status code if not provided" do
       error = Lob::LobError.new("hello")
-      error.to_s.must_equal("hello")
+      error.to_s.must_include("hello")
     end
   end
 


### PR DESCRIPTION
I am writing a lob based app and if I get something wrong I only get this message:

```
     Lob::LobError:
        Invalid response object:
```

I don't know if that was the intention but I think that it is so much better to respond something like

```
     Lob::LobError:
       (Status 422) Invalid response object:
        {
           "errors": [
               {
                   "message": "addrdess_city is not allowed",
                   "status_code": 422
               }
           ]
       }
```

That way if an exception happens it is really easier to understand the cause.

Also the LobError class was overloading some methods from StandardError I don't know if intentionally but we can achieve the same behaviour without overriding anything.

Some tests are failing right now for me in my environment but were failing before the changes and after the results are the same.