### PR TITLE
route list can accept a single ZIP as input

### DIFF
--- a/lib/lob/v1/route.rb
+++ b/lib/lob/v1/route.rb
@@ -6,7 +6,11 @@ module Lob
       end
 
       def list(options = {})
-        Lob.submit(:get, route_url, options)
+        if options.is_a?(String)
+          Lob.submit(:get, route_url(options))
+        else
+          Lob.submit(:get, route_url, options)
+        end
       end
 
       private

--- a/spec/lob/v1/route_spec.rb
+++ b/spec/lob/v1/route_spec.rb
@@ -5,10 +5,19 @@ describe Lob::V1::Route do
   subject { Lob(api_key: ENV["LOB_API_KEY"]) }
 
   describe "list" do
+
     it "should list routes" do
       zip_code = "94158"
       routes = subject.routes.list(zip_codes: zip_code)
       routes["data"][0]["zip_code"].must_equal(zip_code)
     end
+
+    it "should accept a single ZIP code as input" do
+      zip_code = "94158"
+      routes = subject.routes.list(zip_code)
+      routes["zip_code"].must_equal(zip_code)
+    end
+
   end
+
 end


### PR DESCRIPTION
Now you can do something like:

```ruby
@lob.routes.list('94107')
```

Fixes #123 