### PR TITLE
Ensure JSON.parse is never passed nil

### DIFF
--- a/lib/lob.rb
+++ b/lib/lob.rb
@@ -48,7 +48,7 @@ module Lob
 
   def self.handle_api_error(error)
     begin
-      response = JSON.parse(error.http_body)
+      response = JSON.parse(error.http_body.to_s)
       message = response.fetch("error").fetch("message")
       raise InvalidRequestError.new(message, error.http_code, error.http_body, error.response)
     rescue JSON::ParserError, KeyError


### PR DESCRIPTION
Without this, a `nil` `html_body` will be passed to JSON.parse and raise a `TypeError`. With it, a `JSON::ParserError` will be raised, which will be caught and re-raised as a `LobError` correctly. Allows integrators to handle only `LobError` occurrences and not worry about the more generic `TypeError`.