### PR TITLE
add test for routes list endpoint with multiple zip codes

### DIFF
--- a/spec/lob/v1/route_spec.rb
+++ b/spec/lob/v1/route_spec.rb
@@ -18,6 +18,12 @@ describe Lob::V1::Route do
       routes["zip_code"].must_equal(zip_code)
     end
 
+    it "should list routes given multiple zip codes" do
+      zip_codes = ["94107", "94158"]
+      routes = subject.routes.list(zip_codes: zip_codes)
+      routes["data"][0]["zip_code"].must_equal(zip_codes[0])
+    end
+
   end
 
 end


### PR DESCRIPTION
I added a test that passes multiple zip_codes to the `GET /v1/routes` endpoint. This serves as not only a good test but also as an example for users trying to fetch a combination of routes.