### PR TITLE
feat(examples): adds csv checks and csv letters examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,26 +2,34 @@
 
 This directory contains a collection of ruby example to help get you started using the Lob API. As always, feel free to [contact us](https://lob.com/support) directly if you have any questions.
 
+## /csv_checks/
+
+An example showing how to dynamically create checks from a CSV using HTML, variable data, and Lob's [Checks API](https://lob.com/services/checks).
+
+## /csv_letters/
+
+An example showing how to dynamically create letters from a CSV using HTML, a custom font, variable data, and Lob's [Letters API](https://lob.com/services/letters).
+
 ## /csv_postcards/
 
-An example showing how to dynamically create postcards from a CSV using HTML, a custom font, variable data, and Lob's [Simple Postcard Service](https://lob.com/services/postcards).
+An example showing how to dynamically create postcards from a CSV using HTML, a custom font, variable data, and Lob's [Postcards API](https://lob.com/services/postcards).
 
 ## /checks.rb
 
-An example showing how to create a check using Lob's [Simple Check Service](https://lob.com/services/checks).
+An example showing how to create a check using Lob's [Checks API](https://lob.com/services/checks).
 
 ## /jobs.rb
 
-An example showing how to create objects and jobs using Lob's [Simple Print Service](https://lob.com/services/sps).
+An example showing how to create objects and jobs using Lob's [Jobs API](https://lob.com/services/sps).
 
 ## /letters.rb
 
-And example showing how to create letters using Lob's [Simple Letter Service](https://lob.com/services/letters).
+An example showing how to create a letter using Lob's [Letters API](https://lob.com/services/letters).
 
 ## /postcards.rb
 
-An example showing how to create postcards using Lob's [Simple Postcard Service](https://lob.com/services/postcards).
+An example showing how to create a postcard using Lob's [Postcards API](https://lob.com/services/postcards).
 
-## /verify.rb
+## /verify/
 
 An example showing how to verify an address using the [StreetAddress gem](https://github.com/derrek/street-address) and Lob's verify endpoint. This example saves verified addresses in a CSV file.

--- a/examples/csv_checks/create_checks.rb
+++ b/examples/csv_checks/create_checks.rb
@@ -1,0 +1,48 @@
+$:.unshift File.expand_path("../../lib", File.dirname(__FILE__))
+require 'lob'
+require 'csv'
+
+# Initialize Lob object
+Lob.api_key = 'test_799ff27291c166d10ba191902ad02fb059c'
+@lob = Lob.load
+
+# Create a bank account
+bank_account = @lob.bank_accounts.create(
+  routing_number: "322271627",
+  account_number: "123456789",
+  account_type: "company",
+  signatory: "John Doe"
+)
+
+puts bank_account
+
+# Verify bank account
+@lob.bank_accounts.verify(bank_account['id'], amounts: [23, 12])
+
+# Parse the CSV and create the checks
+CSV.foreach(File.expand_path('../input.csv', __FILE__)) do |row|
+  check = @lob.checks.create(
+    description: 'CSV Test',
+    bank_account: bank_account["id"],
+    to: {
+      name: row[0],
+      address_line1: row[1],
+      address_line2: row[2],
+      address_city: row[3],
+      address_state: row[4],
+      address_zip: row[5],
+      address_country: row[6]
+    },
+    from: {
+      name: 'Lob',
+      address_line1: '123 Main Street',
+      address_city: 'San Francisco',
+      address_state: 'CA',
+      address_zip: '94185',
+      address_country: 'US'
+    },
+    amount: row[7],
+    memo: "For travel reimbursement"
+  )
+  puts check['url']
+end

--- a/examples/csv_checks/input.csv
+++ b/examples/csv_checks/input.csv
@@ -1,0 +1,6 @@
+Pallavi,353 King Street,Apt. 432,San Francisco,CA,94158,US,600.00
+Dom,456 Oak Street,Apt. 102,San Francisco,CA,94185,US,500.00
+Kyle,123 Test Street,Apt. 101,San Francisco,CA,94105,US,400.00
+Kienan,789 Elm Street,Apt. 101,San Francisco,CA,94107,US,300.00
+Sid,111 Washington Street,Apt. 101,San Francisco,CA,94112,US,200.00
+Will,888 Jefferson Street,Apt. 101,San Francisco,CA,94197,US,100.00

--- a/examples/csv_letters/create_letters.rb
+++ b/examples/csv_letters/create_letters.rb
@@ -1,0 +1,41 @@
+$:.unshift File.expand_path("../../lib", File.dirname(__FILE__))
+require 'lob'
+require 'csv'
+
+# Initialize Lob object
+Lob.api_key = 'test_799ff27291c166d10ba191902ad02fb059c'
+@lob = Lob.load
+
+# Load the HTML from letter_template.html
+letter_html = File.open(File.expand_path('../letter_template.html', __FILE__)).read
+
+# Parse the CSV and create the letters.
+CSV.foreach(File.expand_path('../input.csv', __FILE__)) do |row|
+  letter = @lob.letters.create(
+    description: 'CSV Test',
+    to: {
+      name: row[0],
+      address_line1: row[1],
+      address_line2: row[2],
+      address_city: row[3],
+      address_state: row[4],
+      address_zip: row[5],
+      address_country: row[6]
+    },
+    from: {
+      name: 'Lob',
+      address_line1: '123 Main Street',
+      address_city: 'San Francisco',
+      address_state: 'CA',
+      address_zip: '94185',
+      address_country: 'US'
+    },
+    file: letter_html,
+    data: {
+      name: row[0],
+      city: row[3]
+    },
+    color: false
+  )
+  puts letter['url']
+end

--- a/examples/csv_letters/input.csv
+++ b/examples/csv_letters/input.csv
@@ -1,0 +1,6 @@
+Pallavi,353 King Street,Apt. 432,San Francisco,CA,94158,US
+Dom,456 Oak Street ,Apt. 102,San Francisco,CA,94185,US
+Kyle,123 Test Street,Apt. 101,San Francisco,CA,94105,US
+Kienan,789 Elm Street,Apt. 101,San Francisco,CA,94107,US
+Sid,111 Washington Street,Apt. 101,San Francisco,CA,94112,US
+Will,888 Jefferson Street,Apt. 101,San Francisco,CA,94197,US

--- a/examples/csv_letters/letter_template.html
+++ b/examples/csv_letters/letter_template.html
@@ -1,0 +1,33 @@
+<html>
+<head>
+<style>
+  *, *:before, *:after {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+
+  @font-face {
+    font-family: 'Loved by the King';
+    font-style: normal;
+    font-weight: 400;
+    src: url('https://s3-us-west-2.amazonaws.com/lob-assets/LovedbytheKing.ttf') format('truetype');
+  }
+
+  .text {
+    margin-left: 75px;
+    padding-top: 250px;
+    width: 400px;
+    font-family: 'Loved by the King';
+    font-size: 50px;
+    font-weight: 700;
+    color: black;
+  }
+</style>
+</head>
+
+<body>
+  <p class="text">Hello {{name}}!<br/><br/>Join us for this year's summer celebration in {{city}}!</p>
+</body>
+
+</html>

--- a/examples/verify/verify.rb
+++ b/examples/verify/verify.rb
@@ -14,7 +14,7 @@ output = File.open(File.expand_path('../output.csv', __FILE__), 'w')
 
 output.puts ['address_line1', 'address_city', 'address_state', 'address_zip', 'address_country'].join(',')
 
-# Parse the CSV and create the postcards.
+# Parse the input file and verify the addresses
 File.open(File.expand_path('../input.txt', __FILE__)).each_line do |line|
   parsed_address = StreetAddress::US.parse(line)
 

--- a/spec/lob/v1/address_spec.rb
+++ b/spec/lob/v1/address_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 describe Lob::V1::Address do
 
-  let(:sample_params) {
-    {
+  before :each do
+    @sample_params = {
       name: "John Doe",
       address_line1: "325 Berry Street",
       address_city: "San Francisco",
@@ -14,7 +14,7 @@ describe Lob::V1::Address do
         test: 'stuff'
       }
     }
-  }
+  end
 
   subject { Lob(api_key: ENV["LOB_API_KEY"]) }
 
@@ -22,10 +22,10 @@ describe Lob::V1::Address do
 
     it "should verify an address" do
       result = subject.addresses.verify(
-        address_line1: sample_params[:address_line1],
-        address_city:  sample_params[:address_city],
-        address_state: sample_params[:address_state],
-        address_zip:   sample_params[:address_zip]
+        address_line1: @sample_params[:address_line1],
+        address_city:  @sample_params[:address_city],
+        address_state: @sample_params[:address_state],
+        address_zip:   @sample_params[:address_zip]
       )
 
       result["address"]["address_country"].must_equal("US")
@@ -42,25 +42,26 @@ describe Lob::V1::Address do
 
   describe "create" do
     it "should create an address" do
-      result = subject.addresses.create sample_params
-      assert /#{result["name"]}/i =~ sample_params[:name]
+      result = subject.addresses.create @sample_params
+
+      result["name"].must_equal(@sample_params[:name])
     end
   end
 
 
   describe "find" do
     it "should find an address" do
-      new_address = subject.addresses.create sample_params
+      new_address = subject.addresses.create @sample_params
 
       find_result = subject.addresses.find(new_address["id"])
-      assert /#{find_result["name"]}/i =~ sample_params[:name]
+      find_result["name"].must_equal(@sample_params[:name])
     end
   end
 
 
   describe "destroy" do
     it "should delete an address" do
-      new_address = subject.addresses.create sample_params
+      new_address = subject.addresses.create @sample_params
 
       delete_result = subject.addresses.destroy(new_address["id"])
       assert_equal(new_address["id"], delete_result["id"])


### PR DESCRIPTION
What: Ensure there is a create checks from csv example. Ensure there is a create letters from csv example.

Why: Wrapper tasks

Details:
- Made csv_checks and csv_letters examples
- Edited address spec to be consistent with the syntax of the other tests