### PR TITLE
refactor(tests): Remove need to supply API key to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,5 @@ rvm:
 
 env:
   JRUBY_OPTS=--2.0
-  - LOB_API_KEY=test_799ff27291c166d10ba191902ad02fb059c
 
 script: bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -190,11 +190,9 @@ To contribute, please see the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 Tests are written using MiniTest, a testing library that comes with Ruby stdlib.
 
-You'll need to pass in your Lob.com API as the environment variable `LOB_API_KEY`, to run the tests. Be sure to use your Test API key, and not the Live one.
-
 Here's how you can run the tests:
 
-    LOB_API_KEY=your_test_api_key bundle exec rake test
+    `bundle exec rake test`
 
 You can also configure, TravisCI for your fork of the repository and it'll run the tests for you, when you push.
 

--- a/spec/lob/v1/address_spec.rb
+++ b/spec/lob/v1/address_spec.rb
@@ -16,7 +16,7 @@ describe Lob::V1::Address do
     }
   end
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "verify" do
 

--- a/spec/lob/v1/area_spec.rb
+++ b/spec/lob/v1/area_spec.rb
@@ -10,7 +10,7 @@ describe Lob::V1::Area do
     }
   end
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list areas" do

--- a/spec/lob/v1/bank_account_spec.rb
+++ b/spec/lob/v1/bank_account_spec.rb
@@ -11,7 +11,7 @@ describe Lob::V1::BankAccount do
     }
   end
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list bank accounts" do

--- a/spec/lob/v1/check_spec.rb
+++ b/spec/lob/v1/check_spec.rb
@@ -23,7 +23,7 @@ describe Lob::V1::Check do
     }
   end
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list checks" do

--- a/spec/lob/v1/country_spec.rb
+++ b/spec/lob/v1/country_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Lob::V1::Country do
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list countries" do

--- a/spec/lob/v1/job_spec.rb
+++ b/spec/lob/v1/job_spec.rb
@@ -19,7 +19,7 @@ describe Lob::V1::Job do
     @test_setting_id = 201
   end
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list jobs" do

--- a/spec/lob/v1/letter_spec.rb
+++ b/spec/lob/v1/letter_spec.rb
@@ -15,7 +15,7 @@ describe Lob::V1::Letter do
     }
   end
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list letter" do

--- a/spec/lob/v1/object_spec.rb
+++ b/spec/lob/v1/object_spec.rb
@@ -9,7 +9,7 @@ describe Lob::V1::Object do
     @test_setting_id = 201
   end
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list objects" do

--- a/spec/lob/v1/postcard_spec.rb
+++ b/spec/lob/v1/postcard_spec.rb
@@ -20,7 +20,7 @@ describe Lob::V1::Postcard do
     }
   end
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list postcards" do

--- a/spec/lob/v1/route_spec.rb
+++ b/spec/lob/v1/route_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Lob::V1::Route do
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "find" do
 

--- a/spec/lob/v1/setting_spec.rb
+++ b/spec/lob/v1/setting_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Lob::V1::Setting do
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list settings" do

--- a/spec/lob/v1/state_spec.rb
+++ b/spec/lob/v1/state_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Lob::V1::State do
 
-  subject { Lob(api_key: ENV["LOB_API_KEY"]) }
+  subject { Lob(api_key: API_KEY) }
 
   describe "list" do
     it "should list states" do

--- a/spec/lob_spec.rb
+++ b/spec/lob_spec.rb
@@ -50,27 +50,27 @@ describe Lob do
   end
 
   it "should handle API errors gracefully" do
-    lob = Lob.load(api_key: ENV["LOB_API_KEY"])
+    lob = Lob.load(api_key: API_KEY)
     assert_raises Lob::InvalidRequestError do
       lob.objects.create(name: "Test", file: "https://lob.com/test.pdf", bad_param: "bad_value")
     end
   end
 
   it "should work when no api_version is provided" do
-    lob = Lob.load(api_key: ENV["LOB_API_KEY"])
+    lob = Lob.load(api_key: API_KEY)
     Lob.api_version = nil
     lob.addresses.list
     Lob.api_version = "2014-11-24"
   end
 
   it "should include the raw response" do
-    lob = Lob.load(api_key: ENV["LOB_API_KEY"])
+    lob = Lob.load(api_key: API_KEY)
     result = lob.addresses.list
     assert result._response.headers.include?(:content_type)
   end
 
   it "should include response headers for errors" do
-    lob = Lob.load(api_key: ENV["LOB_API_KEY"])
+    lob = Lob.load(api_key: API_KEY)
     begin
       lob.objects.create(name: "Test", file: "https://lob.com/test.pdf", bad_param: "bad_value")
     rescue Lob::InvalidRequestError => e

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,5 @@ require "lob"
 require "minitest/spec"
 require "minitest/pride"
 require "minitest/autorun"
+
+API_KEY = 'test_799ff27291c166d10ba191902ad02fb059c'


### PR DESCRIPTION
What: No longer need to provide an API key to run tests.

Why: lob-ruby is the only wrapper that requires this. Also, a few tests will fail if certain feature flags  are enabled on the account, so test results vary for different API keys. This eliminates that variability and makes it a bit easier to run tests.

Details:

- Replace environment variable with test API key in `spec_helper.rb`
- Update Readme with new testing instructions.