### PR TITLE
refactor(resource): Refactor classes to inherit from base resource class

### DIFF
--- a/lib/lob.rb
+++ b/lib/lob.rb
@@ -1,14 +1,10 @@
-require "rest-client"
-require "json"
-require 'uri'
+require "lob/v1/client"
 require "lob/version"
 require "lob/errors/lob_error"
 require "lob/errors/invalid_request_error"
 
-# Dynamically require files
-Dir[File.join(File.dirname(__FILE__), 'lob', 'v*', '*.rb')].each {|file| require file }
-
 module Lob
+
   class << self
     attr_accessor :api_key, :api_version, :protocol, :api_host
 
@@ -19,68 +15,10 @@ module Lob
     alias :config :configure
   end
 
-  def self.submit(method, url, parameters={})
-    clientVersion = Lob::VERSION
-
-    begin
-      if method == :get || method == :delete
-        # Hack to URL encode nested objects like metadata.
-        url = "#{url}?#{build_nested_query(parameters)}"
-        response = RestClient.send(method, url, {
-          user_agent: 'Lob/v1 RubyBindings/' + clientVersion,
-          "Lob-Version" => self.api_version
-        })
-      else
-        response = RestClient.send(method, url, parameters, {
-          user_agent: 'Lob/v1 RubyBindings/' + clientVersion,
-          "Lob-Version" => self.api_version
-        })
-      end
-
-      body = JSON.parse(response)
-
-      body.define_singleton_method(:_response) do
-        response
-      end
-
-      return body
-
-    rescue RestClient::ExceptionWithResponse => e
-      handle_api_error(e)
-    end
-  end
-
   def self.load(options={})
     Lob(options)
   end
 
-  def self.handle_api_error(error)
-    begin
-      response = JSON.parse(error.http_body.to_s)
-      message = response.fetch("error").fetch("message")
-      raise InvalidRequestError.new(message, error.http_code, error.http_body, error.response)
-    rescue JSON::ParserError, KeyError
-      # :nocov:
-      raise LobError.new("Invalid response object:", error.http_code, error.http_body)
-      # :nocov:
-    end
-  end
-
-  def self.build_nested_query(value, prefix = nil)
-    case value
-    when Array
-      value.map { |v|
-        build_nested_query(v, "#{prefix}[]")
-      }.join("&")
-    when Hash
-      value.map { |k, v|
-        build_nested_query(v, prefix ? "#{prefix}[#{URI.encode_www_form_component(k)}]" : URI.encode_www_form_component(k))
-      }.reject(&:empty?).join('&')
-    else
-      raise ArgumentError, "value must be an Array or Hash" if prefix.nil?
-      "#{prefix}=#{URI.encode_www_form_component(value)}"
-    end
-  end
 end
 
 def Lob(options={})
@@ -93,5 +31,6 @@ def Lob(options={})
     raise ArgumentError.new(":api_key is a required argument to initialize Lob")
   end
 
-  Lob::V1::Resource.new(options)
+  Lob::V1::Client.new(options)
+
 end

--- a/lib/lob/v1/address.rb
+++ b/lib/lob/v1/address.rb
@@ -1,39 +1,22 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Address
+    class Address < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
+      def initialize(config)
+        super(config)
+        @endpoint = "addresses"
       end
 
       def verify(options={})
-        Lob.submit(:post, address_verify_url, options)
-      end
-
-      def list(options={})
-        Lob.submit(:get, address_url, options)
-      end
-
-      def find(address_id)
-        Lob.submit :get, address_url(address_id)
-      end
-
-      def create(options = {})
-        Lob.submit :post, address_url, options
-      end
-
-      def destroy(address_id)
-        Lob.submit :delete, address_url(address_id)
+        submit :post, address_verify_url, options
       end
 
       private
 
-      def address_url(address_id = nil)
-        @resource.construct_url("addresses", address_id)
-      end
-
       def address_verify_url
-        @resource.construct_url("verify")
+        "#{base_url}/verify"
       end
 
     end

--- a/lib/lob/v1/area.rb
+++ b/lib/lob/v1/area.rb
@@ -1,27 +1,16 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Area
-      def initialize(resource)
-        @resource = resource
+    class Area < Lob::V1::Resource
+
+      undef_method :destroy
+
+      def initialize(config)
+        super(config)
+        @endpoint = "areas"
       end
 
-      def list(options = {})
-        Lob.submit(:get, area_url, options)
-      end
-
-      def find(lob_object_id)
-        Lob.submit :get, area_url(lob_object_id)
-      end
-
-      def create(options = {})
-        Lob.submit :post, area_url, options
-      end
-
-      private
-
-      def area_url(area_id = nil)
-        @resource.construct_url("areas", area_id)
-      end
     end
   end
 end

--- a/lib/lob/v1/bank_account.rb
+++ b/lib/lob/v1/bank_account.rb
@@ -1,35 +1,22 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class BankAccount
+    class BankAccount < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
-      end
-
-      def list(options={})
-        Lob.submit(:get, bank_account_url, options)
-      end
-
-      def find(bank_account_id)
-        Lob.submit :get, bank_account_url(bank_account_id)
-      end
-
-      def create(options = {})
-        Lob.submit :post, bank_account_url, options
-      end
-
-      def destroy(bank_account_id)
-        Lob.submit :delete, bank_account_url(bank_account_id)
+      def initialize(config)
+        super(config)
+        @endpoint = "bank_accounts"
       end
 
       def verify(bank_account_id, options = {})
-        Lob.submit :post, "#{bank_account_url(bank_account_id)}/verify", options
+        submit :post, verify_url(bank_account_id), options
       end
 
       private
 
-      def bank_account_url(bank_account_id = nil)
-        @resource.construct_url("bank_accounts", bank_account_id)
+      def verify_url(bank_account_id)
+        "#{resource_url(bank_account_id)}/verify"
       end
 
     end

--- a/lib/lob/v1/check.rb
+++ b/lib/lob/v1/check.rb
@@ -1,31 +1,12 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Check
+    class Check < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
-      end
-
-      def list(options={})
-        Lob.submit(:get, check_url, options)
-      end
-
-      def find(check_id)
-        Lob.submit :get, check_url(check_id)
-      end
-
-      def create(options = {})
-        Lob.submit :post, check_url, options
-      end
-
-      def destroy(check_id)
-        Lob.submit :delete, check_url(check_id)
-      end
-
-      private
-
-      def check_url(check_id = nil)
-        @resource.construct_url("checks", check_id)
+      def initialize(config)
+        super(config)
+        @endpoint = "checks"
       end
 
     end

--- a/lib/lob/v1/client.rb
+++ b/lib/lob/v1/client.rb
@@ -1,0 +1,78 @@
+require_relative "address"
+require_relative "area"
+require_relative "bank_account"
+require_relative "check"
+require_relative "country"
+require_relative "job"
+require_relative "letter"
+require_relative "object"
+require_relative "postcard"
+require_relative "route"
+require_relative "setting"
+require_relative "state"
+
+module Lob
+  module V1
+    class Client
+
+      attr_reader :config
+
+      def initialize(config)
+        @config = config
+      end
+
+      def options
+        config
+      end
+
+      def areas
+        Lob::V1::Area.new(config)
+      end
+
+      def addresses
+        Lob::V1::Address.new(config)
+      end
+
+      def bank_accounts
+        Lob::V1::BankAccount.new(config)
+      end
+
+      def checks
+        Lob::V1::Check.new(config)
+      end
+
+      def countries
+        Lob::V1::Country.new(config)
+      end
+
+      def jobs
+        Lob::V1::Job.new(config)
+      end
+
+      def letters
+        Lob::V1::Letter.new(config)
+      end
+
+      def objects
+        Lob::V1::Object.new(config)
+      end
+
+      def postcards
+        Lob::V1::Postcard.new(config)
+      end
+
+      def routes
+        Lob::V1::Route.new(config)
+      end
+
+      def settings
+        Lob::V1::Setting.new(config)
+      end
+
+      def states
+        Lob::V1::State.new(config)
+      end
+
+    end
+  end
+end

--- a/lib/lob/v1/country.rb
+++ b/lib/lob/v1/country.rb
@@ -1,19 +1,14 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Country
+    class Country < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
-      end
+      undef_method :find, :create, :destroy
 
-      def list(options={})
-        Lob.submit(:get, country_url, options)
-      end
-
-      private
-
-      def country_url
-        @resource.construct_url("countries")
+      def initialize(config)
+        super(config)
+        @endpoint = "countries"
       end
 
     end

--- a/lib/lob/v1/job.rb
+++ b/lib/lob/v1/job.rb
@@ -1,17 +1,14 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Job
+    class Job < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
-      end
+      undef_method :destroy
 
-      def list(options={})
-        Lob.submit(:get, job_url, options)
-      end
-
-      def find(job_id)
-        Lob.submit :get, job_url(job_id)
+      def initialize(config)
+        super(config)
+        @endpoint = "jobs"
       end
 
       def create(options = {})
@@ -22,16 +19,9 @@ module Lob
         else
           options["object1"] = options[:objects]
         end
-        options.delete(:objects)
+        options.delete :objects
 
-        Lob.submit :post, job_url, options
-      end
-
-
-      private
-
-      def job_url(job_id = nil)
-        @resource.construct_url("jobs", job_id)
+        submit :post, endpoint_url, options
       end
 
     end

--- a/lib/lob/v1/letter.rb
+++ b/lib/lob/v1/letter.rb
@@ -1,31 +1,12 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Letter
+    class Letter < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
-      end
-
-      def list(options={})
-        Lob.submit(:get, letter_url, options)
-      end
-
-      def find(letter_id)
-        Lob.submit :get, letter_url(letter_id)
-      end
-
-      def create(options = {})
-        Lob.submit :post, letter_url, options
-      end
-
-      def destroy(letter_id)
-        Lob.submit :delete, letter_url(letter_id)
-      end
-
-      private
-
-      def letter_url(job_id = nil)
-        @resource.construct_url("letters", job_id)
+      def initialize(config)
+        super(config)
+        @endpoint = "letters"
       end
 
     end

--- a/lib/lob/v1/object.rb
+++ b/lib/lob/v1/object.rb
@@ -1,31 +1,12 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Object
+    class Object < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
-      end
-
-      def list(options = {})
-        Lob.submit(:get, object_url, options)
-      end
-
-      def find(lob_object_id)
-        Lob.submit :get, object_url(lob_object_id)
-      end
-
-      def create(options = {})
-        Lob.submit :post, object_url, options
-      end
-
-      def destroy(lob_object_id)
-        Lob.submit :delete, object_url(lob_object_id)
-      end
-
-      private
-
-      def object_url(lob_object_id = nil)
-        @resource.construct_url("objects", lob_object_id)
+      def initialize(config)
+        super(config)
+        @endpoint = "objects"
       end
 
     end

--- a/lib/lob/v1/postcard.rb
+++ b/lib/lob/v1/postcard.rb
@@ -1,31 +1,12 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Postcard
+    class Postcard < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
-      end
-
-      def list(options={})
-        Lob.submit(:get, postcard_url, options)
-      end
-
-      def find(postcard_id)
-        Lob.submit :get, postcard_url(postcard_id)
-      end
-
-      def create(options = {})
-        Lob.submit :post, postcard_url, options
-      end
-
-      def destroy(postcard_id)
-        Lob.submit :delete, postcard_url(postcard_id)
-      end
-
-      private
-
-      def postcard_url(postcard_id = nil)
-        @resource.construct_url("postcards", postcard_id)
+      def initialize(config)
+        super(config)
+        @endpoint = "postcards"
       end
 
     end

--- a/lib/lob/v1/route.rb
+++ b/lib/lob/v1/route.rb
@@ -1,27 +1,24 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Route
-      def initialize(resource)
-        @resource = resource
-      end
+    class Route < Lob::V1::Resource
 
-      def find(route)
-        Lob.submit :get, route_url(route)
+      undef_method :create, :destroy
+
+      def initialize(config)
+        super(config)
+        @endpoint = "routes"
       end
 
       def list(options = {})
         if options.is_a?(String)
-          Lob.submit(:get, route_url(options))
+          submit :get, resource_url(options)
         else
-          Lob.submit(:get, route_url, options)
+          submit :get, endpoint_url, options
         end
       end
 
-      private
-
-      def route_url(route_id = nil)
-        @resource.construct_url("routes", route_id)
-      end
     end
   end
 end

--- a/lib/lob/v1/setting.rb
+++ b/lib/lob/v1/setting.rb
@@ -1,23 +1,14 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class Setting
+    class Setting < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
-      end
+      undef_method :create, :destroy
 
-      def list(options={})
-        Lob.submit(:get, setting_url, options)
-      end
-
-      def find(setting_id)
-        Lob.submit :get, setting_url(setting_id)
-      end
-
-      private
-
-      def setting_url(setting_id = nil)
-        @resource.construct_url("settings", setting_id)
+      def initialize(config)
+        super(config)
+        @endpoint = "settings"
       end
 
     end

--- a/lib/lob/v1/state.rb
+++ b/lib/lob/v1/state.rb
@@ -1,19 +1,14 @@
+require_relative "resource"
+
 module Lob
   module V1
-    class State
+    class State < Lob::V1::Resource
 
-      def initialize(resource)
-        @resource = resource
-      end
+      undef_method :find, :create, :destroy
 
-      def list(options={})
-        Lob.submit(:get, state_url, options)
-      end
-
-      private
-
-      def state_url
-        @resource.construct_url("states")
+      def initialize(config)
+        super(config)
+        @endpoint = "states"
       end
 
     end

--- a/spec/lob_spec.rb
+++ b/spec/lob_spec.rb
@@ -8,7 +8,7 @@ describe Lob do
   end
 
   it "should return the resource object for the valid version" do
-    Lob(api_key: "test", api_version: "2014-11-25").must_be_kind_of(Lob::V1::Resource)
+    Lob(api_key: "test", api_version: "2014-11-25").must_be_kind_of(Lob::V1::Client)
   end
 
   it "should *not* raise an error if API key has been on module and not passed as option" do
@@ -46,7 +46,7 @@ describe Lob do
     Lob.api_key = "test"
     Lob.load.wont_be_nil
 
-    Lob.load(api_key: "test").must_be_kind_of(Lob::V1::Resource)
+    Lob.load(api_key: "test").must_be_kind_of(Lob::V1::Client)
   end
 
   it "should handle API errors gracefully" do


### PR DESCRIPTION
**What**: This refactoring provides a base `Resource` class, from which all other resources (e.g., `Postcard`, `Letters`, etc.) inherit from. It also moves the logic for HTTP requests to the `Resource` class rather than the `Lob` module.

**Why**: The changes involving the `Resource` class remove a lot of duplicated code that was present, specifically the `find`, `create`, `list` and `destroy` methods that were present on (nearly) every resource.

The changes involving the moving of the HTTP requests were made so that the resources behave more like models, responsible for their own communication with the Lob API, not depending on the larger `Lob` module for these communications.

_Details_:

- The old `Resource` class, which was responsible for creating new resources, has been replaced with a Client class.

- The `Resource` class is now a superclass for all of the resource classes, which comes with `list`, `find`, `create`, and `destroy` methods.

- For resource subclasses without some of these methods (for example, the `State` resource only has the `list` method), Ruby's `undef_method` is used to remove the subclasses ability to respond to those methods.