### PR TITLE
feat(ruby-version): Remove support for Ruby 1.9.3 and add support for 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ language: ruby
 sudo: false
 
 rvm:
-  - 1.9.3
   - jruby
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.0
+  - 2.3.1
 
 env:
   JRUBY_OPTS=--2.0


### PR DESCRIPTION
**What & Why**

Remove support for Ruby 1.9.3 as it has not been maintained since February 2014.

Also, add support for Ruby 2.3, as it has been out for nearly a year.