### PR TITLE
feat(config): Update config to be more idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,10 @@ For optional parameters and other details, refer to the docs [here](https://lob.
 
 ```ruby
 # To initialize a Lob object
-@lob = Lob.load(api_key: "your-api-key")
+lob = Lob::Client.new(api_key: "your-api-key")
 
-# Alternatively, to set the API key for all calls in the future
-Lob.api_key = "your-api-key"
-@lob = Lob.load
-```
-
-#### Or if you want some detailed configuration
-
-```ruby
-Lob.configure do |config|
-  config.api_key = "your-api-key"    # get your own at http://lob.com :)
-  config.api_version = "2014-12-18"  # override the API version
-end
+# To initialize a Lob object with an older API version
+lob = Lob::Client.new(api_key: "your-api-key", api_version: "2014-12-18")
 ```
 
 #### Caution: Pass zero-prefixed zip codes as strings
@@ -88,7 +78,7 @@ The Ruby interpreter assumes it's not of base-10 and tries to convert it to base
 You can access response headers via a hidden `headers` method on the response hash.
 
 ```ruby
-addresses = @lob.addresses.list
+addresses = lob.addresses.list
 
 addresses._response.headers[:content_type]
 # => "application/json; charset=utf-8"
@@ -104,7 +94,7 @@ You can also access headers from `Lob::InvalidRequestError`s.
 
 ```ruby
 begin
-  @lob.objects.create(name: "Test", file: "https://lob.com/test.pdf", bad_param: "bad_value")
+  lob.objects.create(name: "Test", file: "https://lob.com/test.pdf", bad_param: "bad_value")
 rescue Lob::InvalidRequestError => e
   e._response.headers[:content_type]
   # => "application/json; charset=utf-8"
@@ -192,7 +182,7 @@ Tests are written using MiniTest, a testing library that comes with Ruby stdlib.
 
 Here's how you can run the tests:
 
-    `bundle exec rake test`
+    bundle exec rake test
 
 You can also configure, TravisCI for your fork of the repository and it'll run the tests for you, when you push.
 

--- a/examples/checks.rb
+++ b/examples/checks.rb
@@ -2,11 +2,10 @@ $:.unshift File.expand_path("../lib", File.dirname(__FILE__))
 require 'lob'
 
 # initialize Lob object
-Lob.api_key = 'test_799ff27291c166d10ba191902ad02fb059c'
-@lob = Lob.load
+lob = Lob::Client.new(api_key: 'test_799ff27291c166d10ba191902ad02fb059c')
 
 # create an address
-to_address = @lob.addresses.create(
+to_address = lob.addresses.create(
   name: "John Doe",
   address_line1: "104 Printing Boulevard",
   address_city: "Boston",
@@ -16,7 +15,7 @@ to_address = @lob.addresses.create(
 )
 
 # create a from address
-from_address = @lob.addresses.create(
+from_address = lob.addresses.create(
   name: "Jane Doe",
   address_line1: "123 Hello Ave",
   address_city: "Providence",
@@ -26,7 +25,7 @@ from_address = @lob.addresses.create(
 )
 
 # create a bank account
-bank_account = @lob.bank_accounts.create(
+bank_account = lob.bank_accounts.create(
   routing_number: "322271627",
   account_number: "123456789",
   account_type: "company",
@@ -34,10 +33,10 @@ bank_account = @lob.bank_accounts.create(
 )
 
 puts bank_account
-@lob.bank_accounts.verify(bank_account['id'], amounts: [23, 12])
+lob.bank_accounts.verify(bank_account['id'], amounts: [23, 12])
 
 # send a $1000 check using an already created bank and address
-puts @lob.checks.create(
+puts lob.checks.create(
   description: "Test Check",
   check_number: "10000",
   bank_account: bank_account["id"],

--- a/examples/csv_checks/create_checks.rb
+++ b/examples/csv_checks/create_checks.rb
@@ -3,11 +3,10 @@ require 'lob'
 require 'csv'
 
 # Initialize Lob object
-Lob.api_key = 'test_799ff27291c166d10ba191902ad02fb059c'
-@lob = Lob.load
+lob = Lob::Client.new(api_key: 'test_799ff27291c166d10ba191902ad02fb059c')
 
 # Create a bank account
-bank_account = @lob.bank_accounts.create(
+bank_account = lob.bank_accounts.create(
   routing_number: "322271627",
   account_number: "123456789",
   account_type: "company",
@@ -17,11 +16,11 @@ bank_account = @lob.bank_accounts.create(
 puts bank_account
 
 # Verify bank account
-@lob.bank_accounts.verify(bank_account['id'], amounts: [23, 12])
+lob.bank_accounts.verify(bank_account['id'], amounts: [23, 12])
 
 # Parse the CSV and create the checks
 CSV.foreach(File.expand_path('../input.csv', __FILE__)) do |row|
-  check = @lob.checks.create(
+  check = lob.checks.create(
     description: 'CSV Test',
     bank_account: bank_account["id"],
     to: {

--- a/examples/csv_letters/create_letters.rb
+++ b/examples/csv_letters/create_letters.rb
@@ -3,15 +3,14 @@ require 'lob'
 require 'csv'
 
 # Initialize Lob object
-Lob.api_key = 'test_799ff27291c166d10ba191902ad02fb059c'
-@lob = Lob.load
+lob = Lob::Client.new(api_key: 'test_799ff27291c166d10ba191902ad02fb059c')
 
 # Load the HTML from letter_template.html
 letter_html = File.open(File.expand_path('../letter_template.html', __FILE__)).read
 
 # Parse the CSV and create the letters.
 CSV.foreach(File.expand_path('../input.csv', __FILE__)) do |row|
-  letter = @lob.letters.create(
+  letter = lob.letters.create(
     description: 'CSV Test',
     to: {
       name: row[0],

--- a/examples/csv_postcards/create_postcards.rb
+++ b/examples/csv_postcards/create_postcards.rb
@@ -3,8 +3,7 @@ require 'lob'
 require 'csv'
 
 # Initialize Lob object
-Lob.api_key = 'test_799ff27291c166d10ba191902ad02fb059c'
-@lob = Lob.load
+lob = Lob::Client.new(api_key: 'test_799ff27291c166d10ba191902ad02fb059c')
 
 # Load the HTML from postcard_front.html and postcard_back.html.
 front_html = File.open(File.expand_path('../postcard_front.html', __FILE__)).read
@@ -12,7 +11,7 @@ back_html = File.open(File.expand_path('../postcard_back.html', __FILE__)).read
 
 # Parse the CSV and create the postcards.
 CSV.foreach(File.expand_path('../input.csv', __FILE__)) do |row|
-  postcard = @lob.postcards.create(
+  postcard = lob.postcards.create(
     description: 'CSV Test',
     to: {
       name: row[5],

--- a/examples/letters.rb
+++ b/examples/letters.rb
@@ -2,8 +2,7 @@ $:.unshift File.expand_path("../lib", File.dirname(__FILE__))
 require 'lob'
 
 # initialize Lob object
-Lob.api_key = 'test_799ff27291c166d10ba191902ad02fb059c'
-@lob = Lob.load
+lob = Lob::Client.new(api_key: 'test_799ff27291c166d10ba191902ad02fb059c')
 
 html = %{
 <html>
@@ -42,7 +41,7 @@ html = %{
 }
 
 # create a to address
-to_address = @lob.addresses.create(
+to_address = lob.addresses.create(
   name: "ToAddress",
   address_line1: "120 6th Ave",
   address_city: "Boston",
@@ -52,7 +51,7 @@ to_address = @lob.addresses.create(
 )
 
 # create a from address
-from_address = @lob.addresses.create(
+from_address = lob.addresses.create(
   name: "FromAddress",
   address_line1: "120 6th Ave",
   address_city: "Boston",
@@ -62,7 +61,7 @@ from_address = @lob.addresses.create(
 )
 
 # send the letter
-puts @lob.letters.create(
+puts lob.letters.create(
   description: "Test letter",
   to: to_address["id"],
   from: from_address["id"],

--- a/examples/postcards.rb
+++ b/examples/postcards.rb
@@ -2,8 +2,7 @@ $:.unshift File.expand_path("../lib", File.dirname(__FILE__))
 require 'lob'
 
 # initialize Lob object
-Lob.api_key = 'test_799ff27291c166d10ba191902ad02fb059c'
-@lob = Lob.load
+lob = Lob::Client.new(api_key: 'test_799ff27291c166d10ba191902ad02fb059c')
 
 # HTML to send to the server
 html = %{
@@ -56,7 +55,7 @@ html = %{
 }
 
 # create a to address
-to_address = @lob.addresses.create(
+to_address = lob.addresses.create(
   name: "ToAddress",
   address_line1: "120 6th Ave",
   address_city: "Boston",
@@ -66,7 +65,7 @@ to_address = @lob.addresses.create(
 )
 
 # create a from address
-from_address = @lob.addresses.create(
+from_address = lob.addresses.create(
   name: "FromAddress",
   address_line1: "120 6th Ave",
   address_city: "Boston",
@@ -76,7 +75,7 @@ from_address = @lob.addresses.create(
 )
 
 # send a postcard
-puts @lob.postcards.create(
+puts lob.postcards.create(
   description: "Beach Postcard",
   to: to_address["id"],
   from: from_address["id"],

--- a/examples/verify/verify.rb
+++ b/examples/verify/verify.rb
@@ -7,8 +7,7 @@ require 'lob'
 require 'street_address'
 
 # Initialize Lob object
-Lob.api_key = 'test_799ff27291c166d10ba191902ad02fb059c'
-@lob = Lob.load
+lob = Lob::Client.new(api_key: 'test_799ff27291c166d10ba191902ad02fb059c')
 
 output = File.open(File.expand_path('../output.csv', __FILE__), 'w')
 
@@ -18,7 +17,7 @@ output.puts ['address_line1', 'address_city', 'address_state', 'address_zip', 'a
 File.open(File.expand_path('../input.txt', __FILE__)).each_line do |line|
   parsed_address = StreetAddress::US.parse(line)
 
-  verified_address = @lob.addresses.verify(
+  verified_address = lob.addresses.verify(
     address_line1: parsed_address.to_s(:line1),
     address_city: parsed_address.city,
     address_state: parsed_address.state,

--- a/lib/lob.rb
+++ b/lib/lob.rb
@@ -4,33 +4,4 @@ require "lob/errors/lob_error"
 require "lob/errors/invalid_request_error"
 
 module Lob
-
-  class << self
-    attr_accessor :api_key, :api_version, :protocol, :api_host
-
-    def configure
-      yield self
-      true
-    end
-    alias :config :configure
-  end
-
-  def self.load(options={})
-    Lob(options)
-  end
-
-end
-
-def Lob(options={})
-  options[:api_host]     ||= Lob.api_host    || "api.lob.com"
-  options[:protocol]     ||= Lob.protocol    || "https"
-  options[:api_version]  ||= Lob.api_version
-  options[:api_key]      ||= Lob.api_key
-
-  if options[:api_key].nil?
-    raise ArgumentError.new(":api_key is a required argument to initialize Lob")
-  end
-
-  Lob::Client.new(options)
-
 end

--- a/lib/lob/client.rb
+++ b/lib/lob/client.rb
@@ -13,12 +13,12 @@ module Lob
 
     attr_reader :config
 
-    def initialize(config)
-      @config = config
-    end
+    def initialize(config = nil)
+      if config.nil? || config[:api_key].nil?
+        raise ArgumentError.new(":api_key is a required argument to initialize Lob")
+      end
 
-    def options
-      config
+      @config = config
     end
 
     def areas

--- a/lib/lob/resources/resource_base.rb
+++ b/lib/lob/resources/resource_base.rb
@@ -92,7 +92,7 @@ module Lob
       end
 
       def base_url
-        "#{config[:protocol]}://#{config[:api_key]}:@#{config[:api_host]}/v1"
+        "https://#{config[:api_key]}:@api.lob.com/v1"
       end
 
       def endpoint_url

--- a/spec/lob/resources/address_spec.rb
+++ b/spec/lob/resources/address_spec.rb
@@ -16,7 +16,7 @@ describe Lob::Resources::Address do
     }
   end
 
-  subject { Lob(api_key: API_KEY) }
+  subject { Lob::Client.new(api_key: API_KEY) }
 
   describe "verify" do
 

--- a/spec/lob/resources/area_spec.rb
+++ b/spec/lob/resources/area_spec.rb
@@ -10,7 +10,7 @@ describe Lob::Resources::Area do
     }
   end
 
-  subject { Lob(api_key: API_KEY) }
+  subject { Lob::Client.new(api_key: API_KEY) }
 
   describe "list" do
     it "should list areas" do

--- a/spec/lob/resources/bank_account_spec.rb
+++ b/spec/lob/resources/bank_account_spec.rb
@@ -11,7 +11,7 @@ describe Lob::Resources::BankAccount do
     }
   end
 
-  subject { Lob(api_key: API_KEY) }
+  subject { Lob::Client.new(api_key: API_KEY) }
 
   describe "list" do
     it "should list bank accounts" do

--- a/spec/lob/resources/check_spec.rb
+++ b/spec/lob/resources/check_spec.rb
@@ -21,9 +21,10 @@ describe Lob::Resources::Check do
       account_type: "company",
       signatory: "John Doe"
     }
+
   end
 
-  subject { Lob(api_key: API_KEY) }
+  subject { Lob::Client.new(api_key: API_KEY) }
 
   describe "list" do
     it "should list checks" do

--- a/spec/lob/resources/country_spec.rb
+++ b/spec/lob/resources/country_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Lob::Resources::Country do
 
-  subject { Lob(api_key: API_KEY) }
+  subject { Lob::Client.new(api_key: API_KEY) }
 
   describe "list" do
     it "should list countries" do

--- a/spec/lob/resources/letter_spec.rb
+++ b/spec/lob/resources/letter_spec.rb
@@ -15,7 +15,7 @@ describe Lob::Resources::Letter do
     }
   end
 
-  subject { Lob(api_key: API_KEY) }
+  subject { Lob::Client.new(api_key: API_KEY) }
 
   describe "list" do
     it "should list letter" do

--- a/spec/lob/resources/postcard_spec.rb
+++ b/spec/lob/resources/postcard_spec.rb
@@ -20,7 +20,7 @@ describe Lob::Resources::Postcard do
     }
   end
 
-  subject { Lob(api_key: API_KEY) }
+  subject { Lob::Client.new(api_key: API_KEY) }
 
   describe "list" do
     it "should list postcards" do

--- a/spec/lob/resources/resource_base_spec.rb
+++ b/spec/lob/resources/resource_base_spec.rb
@@ -6,16 +6,11 @@ describe Lob::Resources::ResourceBase do
     @api_key = "test"
   end
 
-  subject { Lob(api_key: @api_key) }
+  subject { Lob::Client.new(api_key: @api_key) }
 
   describe "when Lob is initialized" do
-    it "should receive and contain default options when Lob is initialized" do
-      subject.options[:protocol].must_equal "https"
-      subject.options[:api_host].must_equal "api.lob.com"
-    end
-
-    it "should have API key in options" do
-      subject.options[:api_key].must_equal @api_key
+    it "should have API key in config" do
+      subject.config[:api_key].must_equal @api_key
     end
   end
 

--- a/spec/lob/resources/route_spec.rb
+++ b/spec/lob/resources/route_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Lob::Resources::Route do
 
-  subject { Lob(api_key: API_KEY) }
+  subject { Lob::Client.new(api_key: API_KEY) }
 
   describe "find" do
 

--- a/spec/lob/resources/state_spec.rb
+++ b/spec/lob/resources/state_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Lob::Resources::State do
 
-  subject { Lob(api_key: API_KEY) }
+  subject { Lob::Client.new(api_key: API_KEY) }
 
   describe "list" do
     it "should list states" do

--- a/spec/lob_spec.rb
+++ b/spec/lob_spec.rb
@@ -2,77 +2,44 @@ require "spec_helper"
 
 describe Lob do
 
-  after do
-    Lob.api_key = nil
-    Lob.api_version = nil
-  end
-
-  it "should return the resource object for the valid version" do
-    Lob(api_key: "test", api_version: "2014-11-25").must_be_kind_of(Lob::Client)
-  end
-
-  it "should *not* raise an error if API key has been on module and not passed as option" do
-    Lob.api_key = "test"
-    Lob().wont_be_nil
+  it "should return the client object for the valid version" do
+    lob = Lob::Client.new(api_key: "test", api_version: "2014-11-25")
+    lob.must_be_kind_of(Lob::Client)
+    assert lob.config[:api_version] == "2014-11-25"
   end
 
   it "should pass the API key to the resource for the version" do
-    Lob(api_key: "test").options[:api_key].must_equal "test"
+    Lob::Client.new(api_key: "test").config[:api_key].must_equal "test"
   end
 
   it "should raise an error if no API key is supplied" do
     assert_raises ArgumentError do
-      Lob()
+      Lob::Client.new()
     end
-  end
-
-  it "should allow detailed configuration" do
-    Lob.configure do |config|
-      config.api_key = "test"
-      config.api_version = "2014-11-24"
-      config.protocol = "https"
-      config.api_host = "api.lob.com"
-    end
-
-    Lob.api_key.must_equal "test"
-    Lob.api_version.must_equal "2014-11-24"
-    Lob.protocol.must_equal "https"
-    Lob.api_host.must_equal "api.lob.com"
-  end
-
-  it "should work with Lob.load" do
-    Lob.load(api_key: "test").options[:api_key].must_equal "test"
-
-    Lob.api_key = "test"
-    Lob.load.wont_be_nil
-
-    Lob.load(api_key: "test").must_be_kind_of(Lob::Client)
   end
 
   it "should handle API errors gracefully" do
-    lob = Lob.load(api_key: API_KEY)
+    lob = Lob::Client.new(api_key: API_KEY)
     assert_raises Lob::InvalidRequestError do
       lob.postcards.create(name: "Test", file: "https://lob.com/test.pdf", bad_param: "bad_value")
     end
   end
 
   it "should work when no api_version is provided" do
-    lob = Lob.load(api_key: API_KEY)
-    Lob.api_version = nil
+    lob = Lob::Client.new(api_key: API_KEY)
     lob.addresses.list
-    Lob.api_version = "2014-11-24"
   end
 
   it "should include the raw response" do
-    lob = Lob.load(api_key: API_KEY)
+    lob = Lob::Client.new(api_key: API_KEY)
     result = lob.addresses.list
     assert result._response.headers.include?(:content_type)
   end
 
   it "should include response headers for errors" do
-    lob = Lob.load(api_key: API_KEY)
+    lob = Lob::Client.new(api_key: API_KEY)
     begin
-      lob.postcards.create(name: "Test", file: "https://lob.com/test.pdf", bad_param: "bad_value")
+      lob.postcards.create(bad_param: "bad_value")
     rescue Lob::InvalidRequestError => e
       assert e._response.headers.include?(:content_type)
     end


### PR DESCRIPTION
**What**

Update the configuration of the Lob Ruby wrapper to be more idiomatic.

**Why**

Some of the old ways of configuring the wrapper were a bit strange, and added some unnecessary complexity to the code. This PR simplifies the configuration in the following ways:

- Removes `Lob.load`, `Lob.configure` and `Lob()` syntax.
- Uses `Lob::Client.new(api_key: "api-key")` to set up client.
- Removes ability to specify `protocol` and `api_host` (which defaulted to `https` and `api.lob.com` respectively.

**Details**

Updated all examples and specs to conform to new configuration syntax.

