### PR TITLE
chore(examples): Update examples to use new us_verifications endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ end
 
 We've provided various examples for you to try out [here](https://github.com/lob/lob-ruby/tree/master/examples).
 
-There are simple scripts to demonstrate how to create all the core Lob products (checks, letters, postcards, jobs etc.), as well as more complex examples that utilize other libraries and external files:
+There are simple scripts to demonstrate how to create all the core Lob products (checks, letters, postcards, etc.), as well as more complex examples that utilize other libraries and external files:
 
 - [Creating Dynamic Postcards with HTML and Data](https://github.com/lob/lob-ruby/tree/master/examples/csv_postcards)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,10 +18,6 @@ An example showing how to dynamically create postcards from a CSV using HTML, a 
 
 An example showing how to create a check using Lob's [Checks API](https://lob.com/services/checks).
 
-## /jobs.rb
-
-An example showing how to create objects and jobs using Lob's [Jobs API](https://lob.com/services/sps).
-
 ## /letters.rb
 
 An example showing how to create a letter using Lob's [Letters API](https://lob.com/services/letters).
@@ -32,4 +28,4 @@ An example showing how to create a postcard using Lob's [Postcards API](https://
 
 ## /verify/
 
-An example showing how to verify an address using the [StreetAddress gem](https://github.com/derrek/street-address) and Lob's verify endpoint. This example saves verified addresses in a CSV file.
+An example showing how to verify an address using Lob's us_verifications endpoint. This example saves verified addresses in a CSV file.

--- a/examples/verify/input.csv
+++ b/examples/verify/input.csv
@@ -1,0 +1,7 @@
+185 Berry St,Unit 1510,,San Francisco,CA,
+185 Berry St,Ste 1510,,SF,CA,
+185 Berry St,,,SF,CA,
+185 NW Berry St,,,SF,CA,
+1600 Pennsylvania Ave,,,Washington,DC,20500
+5904 Richmond Hwy Ste 340,,,Alexandria,VA,22303-1864
+5905 Richmond Hwy Ste 340,,,Alexandria,VA,

--- a/examples/verify/input.txt
+++ b/examples/verify/input.txt
@@ -1,7 +1,0 @@
-185 Berry St Unit 1510 San Francisco CA
-185 Berry St Ste 1510 SF CA
-185 Berry St SF CA
-185 NW Berry St, SF CA
-1600 Pennsylvania Ave, Washington, DC, 20500
-5904 Richmond Hwy Ste 340 Alexandria VA 22303-1864
-5905 Richmond Hwy Ste 340 Alexandria VA

--- a/examples/verify/verify.rb
+++ b/examples/verify/verify.rb
@@ -3,33 +3,32 @@ $:.unshift File.expand_path("../../lib", File.dirname(__FILE__))
 require 'csv'
 require 'lob'
 
-# Be sure to install the StreetAddress gem.
-require 'street_address'
-
 # Initialize Lob object
 lob = Lob::Client.new(api_key: 'test_799ff27291c166d10ba191902ad02fb059c')
 
 output = File.open(File.expand_path('../output.csv', __FILE__), 'w')
 
-output.puts ['address_line1', 'address_city', 'address_state', 'address_zip', 'address_country'].join(',')
+output.puts ['primary_line', 'secondary_line', 'urbanization', 'last_line', 'deliverability'].join(',')
 
 # Parse the input file and verify the addresses
-File.open(File.expand_path('../input.txt', __FILE__)).each_line do |line|
-  parsed_address = StreetAddress::US.parse(line)
+File.open(File.expand_path('../input.csv', __FILE__)).each_line do |line|
+  address_components = line.split(',')
 
-  verified_address = lob.addresses.verify(
-    address_line1: parsed_address.to_s(:line1),
-    address_city: parsed_address.city,
-    address_state: parsed_address.state,
-    address_country: 'US'
-  )['address']
+  verified_address = lob.us_verifications.verify(
+    primary_line: address_components[0],
+    secondary_line: address_components[1],
+    urbanization: address_components[2],
+    city: address_components[3],
+    state: address_components[4],
+    zip_code: address_components[5]
+  )
 
   output.puts [
-    verified_address['address_line1'],
-    verified_address['address_city'],
-    verified_address['address_state'],
-    verified_address['address_zip'],
-    verified_address['address_country']
+    verified_address['primary_line'],
+    verified_address['secondary_line'],
+    verified_address['urbanization'],
+    verified_address['last_line'],
+    verified_address['deliverability']
   ].join(',')
 
 end


### PR DESCRIPTION
- [x] Replaces old `verify` endpoint with new `us_verifications` endpoint in the example
- [x] Removes `StreetAddress` gem