### PR TITLE
feat(versions): Support Ruby 2.3 and 2.4, removes 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ sudo: false
 
 rvm:
   - jruby
-  - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.0
-  - 2.3.1
+  - 2.3
+  - 2.4
 
 env:
   JRUBY_OPTS=--2.0


### PR DESCRIPTION
- [x] Adds support for all ruby `2.3.x` and `2.4.x` versions.
- [x] Removes support for `2.0.0`, as it was deprecated in February 2016.