### PR TITLE
fix(jruby): Require explicit jruby versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: ruby
 sudo: false
 
 rvm:
-  - jruby
+  - jruby-9.0.5.0
+  - jruby-9.1.9.0
   - 2.1
   - 2.2
   - 2.3

--- a/spec/lob/resources/us_verifications_spec.rb
+++ b/spec/lob/resources/us_verifications_spec.rb
@@ -20,7 +20,7 @@ describe Lob::Resources::USVerifications do
 
       result["recipient"].must_equal(@sample_params[:recipient])
       result["primary_line"].must_equal(@sample_params[:primary_line])
-      result["last_line"].must_equal("SAN FRANCISCO CA 94107-1728")
+      result["last_line"].must_equal("SAN FRANCISCO CA 94107-1234")
     end
   end
 


### PR DESCRIPTION
- [x] Specify explicit JRuby versions to fix travis builds (problem can be found [here](https://github.com/travis-ci/travis-ci/issues/8446))
- [x] Fix test to work with new us_verifications response.