### PR TITLE
Fix commented check amount in checks.rb example

### DIFF
--- a/examples/checks.rb
+++ b/examples/checks.rb
@@ -35,7 +35,7 @@ bank_account = lob.bank_accounts.create(
 puts bank_account
 lob.bank_accounts.verify(bank_account['id'], amounts: [23, 12])
 
-# send a $1000 check using an already created bank and address
+# send a $100 check using an already created bank and address
 puts lob.checks.create(
   description: "Test Check",
   check_number: "10000",


### PR DESCRIPTION
It looks like either the comment or the `amount` are incorrect. Comment said $1,000, `amount` == $100.

[[ this PR is being made entirely from github - I didn't clone and run this fork. Let me know if that's not cool. I figured it was ok since a comment change. ]]