### PR TITLE
feat(av-case): Support 'case' param for us_verifications

### DIFF
--- a/lib/lob/resources/bank_account.rb
+++ b/lib/lob/resources/bank_account.rb
@@ -9,8 +9,14 @@ module Lob
         @endpoint = "bank_accounts"
       end
 
-      def verify(bank_account_id, options = {})
-        submit :post, verify_url(bank_account_id), options
+      def verify(bank_account_id, body = {})
+        request = {
+          method: :post,
+          url: verify_url(bank_account_id),
+          body: body
+        }
+
+        submit request
       end
 
       private

--- a/lib/lob/resources/intl_verifications.rb
+++ b/lib/lob/resources/intl_verifications.rb
@@ -11,8 +11,14 @@ module Lob
         @endpoint = "intl_verifications"
       end
 
-      def verify(options={})
-        submit :post, endpoint_url, options
+      def verify(body={})
+        request = {
+          method: :post,
+          url: endpoint_url,
+          body: body
+        }
+
+        submit request
       end
 
     end

--- a/lib/lob/resources/route.rb
+++ b/lib/lob/resources/route.rb
@@ -13,10 +13,19 @@ module Lob
 
       def list(options = {})
         if options.is_a?(String)
-          submit :get, resource_url(options)
+          request = {
+            method: :get,
+            url: resource_url(options)
+          }
         else
-          submit :get, endpoint_url, options
+          request = {
+            method: :get,
+            url: endpoint_url,
+            query: options
+          }
         end
+
+        submit request
       end
 
     end

--- a/lib/lob/resources/us_verifications.rb
+++ b/lib/lob/resources/us_verifications.rb
@@ -11,8 +11,15 @@ module Lob
         @endpoint = "us_verifications"
       end
 
-      def verify(options={})
-        submit :post, endpoint_url, options
+      def verify(body={}, query={})
+        request = {
+          method: :post,
+          url: endpoint_url,
+          body: body,
+          query: query
+        }
+
+        submit request
       end
 
     end

--- a/lib/lob/resources/us_zip_lookups.rb
+++ b/lib/lob/resources/us_zip_lookups.rb
@@ -11,8 +11,14 @@ module Lob
         @endpoint = "us_zip_lookups"
       end
 
-      def lookup(options={})
-        submit :post, endpoint_url, options
+      def lookup(body={})
+        request = {
+          method: :post,
+          url: endpoint_url,
+          body: body
+        }
+
+        submit request
       end
 
     end

--- a/spec/lob/resources/us_verifications_spec.rb
+++ b/spec/lob/resources/us_verifications_spec.rb
@@ -18,9 +18,13 @@ describe Lob::Resources::USVerifications do
     it "should verify a US address" do
       result = subject.us_verifications.verify @sample_params
 
-      result["recipient"].must_equal(@sample_params[:recipient])
-      result["primary_line"].must_equal(@sample_params[:primary_line])
-      result["last_line"].must_equal("SAN FRANCISCO CA 94107-1234")
+      result["recipient"].must_equal("TEST KEYS DO NOT VERIFY ADDRESSES")
+    end
+
+    it "should verify a US address" do
+      result = subject.us_verifications.verify @sample_params, {case: "proper"}
+
+      result["recipient"].must_equal("Test Keys Do Not Verify Addresses")
     end
   end
 


### PR DESCRIPTION
**What**

Adds support for both `query` and `body` to be passed into `us_verifications.verify`.

Previously, the `submit` method only accepted a `parameters` argument, which was either a set of query params (for get and delete methods) or a post body (for post methods). We needed the ability to be able to support both for the `/v1/us_verifications` endpoint, so I made some tweaks:

- [x] Pass in a hash to the `submit` method, instead of a list of arguments.
- [x] For the `Resource.create` method, pass in `query` _after_ `headers`. If the order of the arguments was `(body, query, headers)`, this would be a breaking change, because Idempotency Keys are currently passed in the headers, so I opted to make the order `(body, headers, query)`.