### PR TITLE
feat(groups): adds the endpoints for suppression groups

### DIFF
--- a/lib/lob/client.rb
+++ b/lib/lob/client.rb
@@ -1,6 +1,7 @@
 require "lob/resources/address"
 require "lob/resources/bank_account"
 require "lob/resources/check"
+require "lob/resources/group"
 require "lob/resources/intl_verifications"
 require "lob/resources/letter"
 require "lob/resources/postcard"
@@ -31,6 +32,10 @@ module Lob
 
     def checks
       Lob::Resources::Check.new(config)
+    end
+    
+    def groups
+      Lob::Resources::Group.new(config)
     end
 
     def intl_verifications

--- a/lib/lob/resources/group.rb
+++ b/lib/lob/resources/group.rb
@@ -1,0 +1,14 @@
+require "lob/resources/resource_base"
+
+module Lob
+  module Resources
+    class Group < Lob::Resources::ResourceBase
+
+      def initialize(config)
+        super(config)
+        @endpoint = "groups"
+      end
+
+    end
+  end
+end

--- a/spec/lob/resources/group_spec.rb
+++ b/spec/lob/resources/group_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+describe Lob::Resources::Group do
+
+  before :each do
+    @sample_params = {
+      description: "Unsubscribe group",
+      metadata: {
+        test: 'stuff'
+      }
+    }
+  end
+
+  subject { Lob::Client.new(api_key: API_KEY) }
+
+  describe "list" do
+    it "should list groups" do
+      assert subject.groups.list["object"] == "list"
+    end
+  end
+
+
+  describe "create" do
+    it "should create a group" do
+      result = subject.groups.create @sample_params
+
+      result["description"].must_equal(@sample_params[:description])
+    end
+  end
+
+
+  describe "find" do
+    it "should find a group" do
+      new_group = subject.groups.create @sample_params
+
+      find_result = subject.groups.find(new_group["id"])
+      find_result["description"].must_equal(@sample_params[:description])
+    end
+  end
+
+
+  describe "destroy" do
+    it "should delete a group" do
+      new_group = subject.groups.create @sample_params
+
+      delete_result = subject.groups.destroy(new_group["id"])
+      assert_equal(new_group["id"], delete_result["id"])
+    end
+  end
+end


### PR DESCRIPTION
**What:** Adds the `/groups` endpoint functionalities.

**Why:** Rolling this feature out in private beta, and two customers who want to use it use our ruby libraries.

**Details:**
- ~Hoping this will interact properly with the feature flag -- I assume it'll check for permissions on their Lob account after making the call to the regular API? Not sure how our libraries work.~ Confirmed that the feature flag is in place, because builds were failing until I added the feature flag to this account.
- Group members endpoint still yet to come.

JIRA: [ENG-11915](https://lobsters.atlassian.net/browse/ENG-11915)