### PR TITLE
chore(advanced-template-syntax): Add test for lists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ WORKDIR /app
 COPY . .
 COPY .git .git
 
-# apk add --no-cache --virtual .build-deps python make g++
-RUN apk add git make gcc libc-dev g++ openssl-dev
+RUN apk add --virtual .build-deps make gcc libc-dev g++ openssl-dev
 RUN bundle install
+RUN apk del .build-deps
+
+RUN apk add git
 
 CMD bundle exec rake test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.4.9-alpine3.11
+
+WORKDIR /app
+COPY . .
+COPY .git .git
+
+# apk add --no-cache --virtual .build-deps python make g++
+RUN apk add git make gcc libc-dev g++ openssl-dev
+RUN bundle install
+
+CMD bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ Here's how you can run the tests:
 
 You can also configure, TravisCI for your fork of the repository and it'll run the tests for you, when you push.
 
+### Testing in Docker
+
+You can also run tests in Docker if you have problems running Ruby on your machine:
+
+````
+docker build -t lob-ruby
+docker run -e API_KEY=YOUR_API_KEY lob-ruby
+````
+
 =======================
 
 Copyright &copy; 2016 Lob.com

--- a/lib/lob/resources/resource_base.rb
+++ b/lib/lob/resources/resource_base.rb
@@ -123,7 +123,7 @@ module Lob
       end
 
       def base_url
-        "https://#{config[:api_key]}:@api.lob.com/v1"
+        https://#{config[:api_key]}:@api.lob.com/v1
       end
 
       def endpoint_url

--- a/lib/lob/resources/resource_base.rb
+++ b/lib/lob/resources/resource_base.rb
@@ -123,7 +123,7 @@ module Lob
       end
 
       def base_url
-        https://#{config[:api_key]}:@api.lob.com/v1
+        "https://#{config[:api_key]}:@api.lob.com/v1"
       end
 
       def endpoint_url

--- a/lob.gemspec
+++ b/lob.gemspec
@@ -18,11 +18,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client", ">= 1.8", "< 3.0"
+  spec.required_ruby_version = '>= 2.0'
+
+  spec.add_dependency "rest-client", ">= 2.0.1", "< 3.0"
 
   spec.add_development_dependency "rake", "~> 10.4.2"
   spec.add_development_dependency "minitest", "~> 5.6.1"
   spec.add_development_dependency "webmock", "~> 1.2"
-  spec.add_development_dependency "coveralls", "~> 0.8.1"
-  spec.add_development_dependency "simplecov", "~> 0.10.0"
+  spec.add_development_dependency "coveralls", "~> 0.8.11"
+  spec.add_development_dependency "simplecov", "~> 0.11.0"
 end

--- a/spec/lob/resources/postcard_spec.rb
+++ b/spec/lob/resources/postcard_spec.rb
@@ -95,6 +95,21 @@ describe Lob::Resources::Postcard do
       result["description"].must_equal(@sample_postcard_params[:description])
     end
 
+    it "should create a postcard with a list merge variable" do
+      new_address = subject.addresses.create @sample_address_params
+
+      result = subject.postcards.create(
+        description: @sample_postcard_params[:description],
+        to: new_address["id"],
+        front: File.new(File.expand_path("../../../samples/postcardfront.pdf", __FILE__)),
+        back: "<h1>Please stand up: {{#users}}{{name}}{{/users}}.</h1>",
+        merge_variables: {"users" => [ { "name" => "Paul" }, { "name" => "Drake" } ] }
+      )
+
+      result["description"].must_equal(@sample_postcard_params[:description])
+
+    end
+
   end
 
 


### PR DESCRIPTION
## What
- This adds a test for advanced template syntax
- Upgrade deprecated packages and require Ruby 2.0 (1.9 is deprecated)
- Merge after ATS is pushed to production