### PR TITLE
Add Boolean handling to ResourceBase#build_nested_query

### DIFF
--- a/lib/lob/resources/resource_base.rb
+++ b/lib/lob/resources/resource_base.rb
@@ -116,6 +116,9 @@ module Lob
           value.map { |k, v|
             build_nested_query(v, prefix ? "#{prefix}[#{URI.encode_www_form_component(k)}]" : URI.encode_www_form_component(k))
           }.reject(&:empty?).join('&')
+        when TrueClass, FalseClass
+          raise ArgumentError, "value must be an Array or Hash" if prefix.nil?
+          "#{prefix}=#{value}"
         else
           raise ArgumentError, "value must be an Array or Hash" if prefix.nil?
           "#{prefix}=#{URI.encode_www_form_component(value)}"


### PR DESCRIPTION
When constructing the body of the query Boolean parameters were being converted to Strings
  as a result of URI.encode_www_form_component(value). In order to pass the variable and have
  it retain its Boolean characteristics it needs to be passed without quotes, as it is a native
  JSON type.

This comes into play when using merge_variables conditionals. Currently everything passes as
  a truthy value. Making conditionals irrelevant.

Under normal conditions I would write some test coverage for this, but since it was a private method it really shouldn't be tested directly. Is there a place where I should test it?