### PR TITLE
fix(merge-variables): convert to json

### DIFF
--- a/lib/lob/resources/resource_base.rb
+++ b/lib/lob/resources/resource_base.rb
@@ -76,6 +76,9 @@ module Lob
           if method == :get || method == :delete
             response = RestClient.send(method, url, headers)
           else
+            if body[:merge_variables] and body[:merge_variables].class == Hash
+              body[:merge_variables] = body[:merge_variables].to_json()
+            end
             response = RestClient.send(method, url, body, headers)
           end
 

--- a/lob.gemspec
+++ b/lob.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client", ">= 1.8", "< 3.0"
+  spec.add_dependency "rest-client", ">= 2.0.1", "< 3.0"
 
   spec.add_development_dependency "rake", "~> 10.4.2"
   spec.add_development_dependency "minitest", "~> 5.6.1"
   spec.add_development_dependency "webmock", "~> 1.2"
-  spec.add_development_dependency "coveralls", "~> 0.8.1"
-  spec.add_development_dependency "simplecov", "~> 0.10.0"
+  spec.add_development_dependency "coveralls", "~> 0.8.13"
+  spec.add_development_dependency "simplecov", "~> 0.11.0"
 end

--- a/spec/lob/resources/check_spec.rb
+++ b/spec/lob/resources/check_spec.rb
@@ -50,6 +50,27 @@ describe Lob::Resources::Check do
 
       result["amount"].to_s.must_equal("2000.12")
     end
+
+    it "should create a check with a merge variable conditional" do
+      new_address = subject.addresses.create @sample_address_params
+
+      new_bank_account = subject.bank_accounts.create(@sample_bank_account_params)
+
+      subject.bank_accounts.verify(new_bank_account["id"], amounts: [1, 2])
+
+      result = subject.checks.create(
+        bank_account: new_bank_account["id"],
+        to: new_address["id"],
+        from: new_address["id"],
+        amount: "2000.12",
+        attachment: "<html>{{#is_awesome}}You are awesome!{{/is_awesome}}</html>",
+        merge_variables: {
+          is_awesome: false
+        }
+      )
+
+      result["merge_variables"]["is_awesome"].must_equal(false)
+    end
   end
 
 

--- a/spec/lob/resources/letter_spec.rb
+++ b/spec/lob/resources/letter_spec.rb
@@ -52,6 +52,26 @@ describe Lob::Resources::Letter do
 
       new_letter["description"].must_equal("TestLetter")
     end
+
+    it "should create a letter with a merge variable object" do
+      new_address = subject.addresses.create @sample_address_params
+
+      new_letter = subject.letters.create(
+        description: "TestLetter",
+        color: true,
+        file: "<html>{{data.name}}</html>",
+        to: new_address["id"],
+        from: @sample_address_params,
+        merge_variables: {
+          data: {
+            name: "Kobe"
+          }
+        }
+      )
+
+      new_letter["description"].must_equal("TestLetter")
+      new_letter["merge_variables"]["data"]["name"].must_equal("Kobe")
+    end
   end
 
 

--- a/spec/lob/resources/postcard_spec.rb
+++ b/spec/lob/resources/postcard_spec.rb
@@ -95,6 +95,31 @@ describe Lob::Resources::Postcard do
       result["description"].must_equal(@sample_postcard_params[:description])
     end
 
+    it "should create a postcard with a merge variable list" do
+      new_address = subject.addresses.create @sample_address_params
+      merge_variables = {
+        list: [
+          {
+            name: "Larissa"
+          },
+          {
+            name: "Larry"
+          }
+        ]
+      }
+
+      result = subject.postcards.create(
+        description: @sample_postcard_params[:description],
+        to: new_address["id"],
+        back: "<html>{{#list}} {{name}} {{/list}}</html>",
+        front: "https://lob.com/postcardfront.pdf",
+        merge_variables: merge_variables
+      )
+
+      result["description"].must_equal(@sample_postcard_params[:description])
+      result["merge_variables"]["list"][0]["name"].must_equal("Larissa")
+      result["merge_variables"]["list"][1]["name"].must_equal("Larry")
+    end
   end
 
 


### PR DESCRIPTION
## What
Converts `merge_variables` into JSON

## Why
The `rest-client` library was doing some weird data type conversions (e.g. booleans into strings, empty hash into empty string)