### PR TITLE
chore: update changelog and bump version to 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-#### 5.1.2 (2021-02-18)
+## [**5.2.0**](https://github.com/lob/lob-ruby/releases/tag/v5.2.0) (2021-05-03)
+- [**188**](https://github.com/lob/lob-ruby/pull/188) Adds support for Self Mailers
+## 5.1.2 (2021-02-18)
 
 ##### Chores and Bug Fixes
 
--[**185**](https://github.com/lob/lob-ruby/pull/185) Bumps rake to 12.3.3, adds Ruby 2.7, update example asset links, other cleanup.
-#### 5.1.1 (2020-05-21)
+- [**185**](https://github.com/lob/lob-ruby/pull/185) Bumps rake to 12.3.3, adds Ruby 2.7, update example asset links, other cleanup.
+## 5.1.1 (2020-05-21)
 
 ##### Chores
 

--- a/lib/lob/version.rb
+++ b/lib/lob/version.rb
@@ -1,3 +1,3 @@
 module Lob
-  VERSION = "5.1.2"
+  VERSION = "5.2.0"
 end


### PR DESCRIPTION
**What**
Updates CHANGELOG.md and bumps client library version identifier from 5.1.2 to 5.2.0

**Why**
Cutting new release with added self mailer support