### PR TITLE
specified ruby version in publish action

### DIFF
--- a/.github/workflows/update_gem.yml
+++ b/.github/workflows/update_gem.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish_gem:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['jruby-9.2.9.0', '2.6', '2.7', '3.0']
     steps:
     - uses: actions/checkout@v2
     - name: Setup


### PR DESCRIPTION
This PR fixes an error that was encountered when attempting to publish to RubyGems. The version(s) of Ruby need to specified. The previous version of this file didn't do that. 