### PR TITLE
Fix for coveralls API for GH actions

### DIFF
--- a/.github/workflows/run_tests_job.yml
+++ b/.github/workflows/run_tests_job.yml
@@ -24,7 +24,7 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        
+        path-to-lcov: ./coverage/lcov/lcov.info
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+## [**5.4.4**](https://github.com/lob/lob-ruby/releases/tag/v5.4.4) (2021-12-16)
+- [**202**](https://github.com/lob/lob-ruby/pull/202) Fix for coveralls API for GH actions and fix for error in resource_base.rb
 ## [**5.4.3**](https://github.com/lob/lob-ruby/releases/tag/v5.4.3) (2021-12-15)
 - [**199**](https://github.com/lob/lob-ruby/pull/199) Refactor ResourceBase to make the options sent to rest-client more configurable
+## [**5.4.2**](https://github.com/lob/lob-ruby/releases/tag/v5.4.2) (2021-12-08)
+- [**198**](https://github.com/lob/lob-ruby/pull/198) specified ruby version in publish action
+- [**195**](https://github.com/lob/lob-ruby/pull/195) added links to example scripts in README file & gh actions to release
 ## [**5.4.1**](https://github.com/lob/lob-ruby/releases/tag/v5.4.1) (2021-09-28)
 - [**193**](https://github.com/lob/lob-ruby/pull/193) Minor patches
 ## [**5.4.0**](https://github.com/lob/lob-ruby/releases/tag/v5.4.0) (2021-09-21)

--- a/lib/lob/resources/resource_base.rb
+++ b/lib/lob/resources/resource_base.rb
@@ -78,13 +78,12 @@ module Lob
           url: url,
         }
         unless method == :delete || method == :get
-          if body&[:merge_variables]&.class == Hash
+          if body and body[:merge_variables] and body[:merge_variables].class == Hash
             body[:merge_variables] = body[:merge_variables].to_json
           end
 
-          client_params[:body] = body
+          client_params[:payload] = body
         end
-
         begin
           response = RestClient::Request.execute(client_params)
 

--- a/lib/lob/version.rb
+++ b/lib/lob/version.rb
@@ -1,3 +1,3 @@
 module Lob
-  VERSION = "5.4.3"
+  VERSION = "5.4.4"
 end

--- a/lob.gemspec
+++ b/lob.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.6.1"
   spec.add_development_dependency "webmock", "~> 1.2"
+  spec.add_development_dependency "simplecov-lcov"
   spec.add_development_dependency "coveralls_reborn", "~> 0.23.1"
   spec.add_development_dependency "simplecov", "~> 0.21.0"
   spec.add_development_dependency "json", "~> 2.3.1"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,12 @@ $:.unshift File.expand_path("../lib", File.dirname(__FILE__))
 require "simplecov"
 require "coveralls"
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-])
+require 'simplecov-lcov'
+
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov::Formatter::LcovFormatter.config.lcov_file_name = 'lcov.info'
+
+SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
 SimpleCov.start
 
 require "lob"


### PR DESCRIPTION
This makes sure that the lcov.info file is generated by the "rake test" command and sent to coveralls.