### PR TITLE
added additional parsing to make sure we can pass hashes into bulk verify methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [**5.4.6**](https://github.com/lob/lob-ruby/releases/tag/v5.4.6) (2022-01-25)
+- [**206**](https://github/com/lob/lob-ruby/pull/206) added additional parsing to make sure we can pass hashes into bulk verify methods
 ## [**5.4.5**](https://github.com/lob/lob-ruby/releases/tag/v5.4.5) (2022-01-11)
 - [**203**](https://github.com/lob/lob-ruby/pull/203) Pass through proxy to rest-client if supplied
 ## [**5.4.4**](https://github.com/lob/lob-ruby/releases/tag/v5.4.4) (2021-12-16)

--- a/lib/lob/resources/bulk_intl_verifications.rb
+++ b/lib/lob/resources/bulk_intl_verifications.rb
@@ -12,6 +12,7 @@ module Lob
       end
 
       def verify(body={})
+        body[:addresses] = body[:addresses].to_json
         request = {
           method: :post,
           url: endpoint_url,

--- a/lib/lob/resources/bulk_us_verifications.rb
+++ b/lib/lob/resources/bulk_us_verifications.rb
@@ -12,6 +12,7 @@ module Lob
       end
 
       def verify(body={}, query={})
+        body[:addresses] = body[:addresses].to_json
         request = {
           method: :post,
           url: endpoint_url,

--- a/lib/lob/version.rb
+++ b/lib/lob/version.rb
@@ -1,3 +1,3 @@
 module Lob
-  VERSION = "5.4.5"
+  VERSION = "5.4.6"
 end

--- a/spec/lob/resources/bulk_intl_verifications_spec.rb
+++ b/spec/lob/resources/bulk_intl_verifications_spec.rb
@@ -11,6 +11,13 @@ describe Lob::Resources::BulkIntlVerifications do
           state: "ONTARIO",
           postal_code: "P0L1N0",
           country: "CA"
+        },
+        {
+          primary_line: "123 Test St",
+          city: "HEARST",
+          state: "ONTARIO",
+          postal_code: "P0L1N0",
+          country: "CA"
         }
       ]
     }
@@ -23,6 +30,8 @@ describe Lob::Resources::BulkIntlVerifications do
       result = subject.bulk_intl_verifications.verify @sample_params
       addresses = result["addresses"]
       address = addresses.first
+      address["recipient"].must_equal("TEST KEYS DO NOT VERIFY ADDRESSES")
+      address = addresses[1]
       address["recipient"].must_equal("TEST KEYS DO NOT VERIFY ADDRESSES")
     end
   end

--- a/spec/lob/resources/bulk_us_verifications_spec.rb
+++ b/spec/lob/resources/bulk_us_verifications_spec.rb
@@ -11,6 +11,13 @@ describe Lob::Resources::BulkUSVerifications do
           city: "SAN FRANCISCO",
           state: "CA",
           zip_code: "94107"
+        },
+        {
+          recipient: "Harry Zhou",
+          primary_line: "325 BERRY ST",
+          city: "SAN FRANCISCO",
+          state: "CA",
+          zip_code: "94107"
         }
       ]
     }
@@ -24,6 +31,10 @@ describe Lob::Resources::BulkUSVerifications do
       addresses = result["addresses"]
       address = addresses.first
       address["recipient"].must_equal("TEST KEYS DO NOT VERIFY ADDRESSES")
+      address = addresses[1]
+      address["recipient"].must_equal("TEST KEYS DO NOT VERIFY ADDRESSES")
+
+
     end
 
     it "should allow 'case' in query params" do
@@ -31,6 +42,9 @@ describe Lob::Resources::BulkUSVerifications do
       addresses = result["addresses"]
       address = addresses.first
       address["recipient"].must_equal("Test Keys Do Not Verify Addresses")
+      address = addresses[1]
+      address["recipient"].must_equal("Test Keys Do Not Verify Addresses")
+
     end
   end
 


### PR DESCRIPTION
This PR makes it so that SDK users don't have to do this `lob.bulk_us_verifications.verify(addresses: addresses.to_json)` and can instead do this `lob.bulk_us_verifications.verify(addresses: addresses)` when making calls to the bulk AV resource. 

For more context, look at this issue https://github.com/lob/lob-ruby/issues/201