### PR TITLE
`require 'lob'` once again loads the library 

### DIFF
--- a/__tests__/Api/Require.unit.rb
+++ b/__tests__/Api/Require.unit.rb
@@ -1,0 +1,21 @@
+# Require.unit.rb
+
+RSpec.describe "Require" do
+  
+      it "works with lob.rb" do
+          Object.send :remove_const, :Lob
+          paths = $".select do |path|
+            path.include?(File.expand_path("../../lib", File.dirname(__FILE__)))
+          end
+          paths.each { |path| $".delete(path) }
+          
+          expect(defined?(Lob)).to eq(nil)
+          expect(defined?(Lob::Configuration)).to eq(nil)
+          
+          require "lob"
+          
+          expect(defined?(Lob)).to eq("constant")
+          expect(defined?(Lob::Configuration)).to eq("constant")
+      end
+
+end

--- a/lib/lob.rb
+++ b/lib/lob.rb
@@ -1,0 +1,1 @@
+require 'openapi_client'


### PR DESCRIPTION
In reference to [this issue](https://github.com/lob/lob-ruby/issues/207).