### PR TITLE
Alter regexes and constants in tests to clear up warnings

### DIFF
--- a/__tests__/Api/Address.unit.rb
+++ b/__tests__/Api/Address.unit.rb
@@ -153,10 +153,10 @@ RSpec.describe "AddressesApi" do
             addressEditable = AddressEditable.new
             fakeAddresses = Array.new(2) { Address.new }
 
-            DATE_FILTER  = { gt: "2020-01-01", lt: "2020-01-31T12" };
+            dateFilter  = { gt: "2020-01-01", lt: "2020-01-31T12" };
             fakeAddresses[0].id = "adr_fakeid"
             allow(addressApi).to receive(:list) { fakeAddresses }
-            response = addressApi.list(date_created: DATE_FILTER)
+            response = addressApi.list(date_created: dateFilter)
 
             expect(response.length()).to eq(2)
             expect(response).to eq(fakeAddresses)
@@ -169,10 +169,10 @@ RSpec.describe "AddressesApi" do
             addressEditable = AddressEditable.new
             fakeAddresses = Array.new(2) { Address.new }
 
-            METADATA  = { fakeMetadata: "fakemetadata" }
+            metadata  = { fakeMetadata: "fakemetadata" }
             fakeAddresses[0].id = "adr_fakeid"
             allow(addressApi).to receive(:list) { fakeAddresses }
-            response = addressApi.list(metadata: METADATA)
+            response = addressApi.list(metadata: metadata)
 
             expect(response.length()).to eq(2)
             expect(response).to eq(fakeAddresses)

--- a/__tests__/Api/BankAccount.unit.rb
+++ b/__tests__/Api/BankAccount.unit.rb
@@ -155,10 +155,10 @@ RSpec.describe "BankAccountsApi" do
             bankAccountWritable = BankAccountWritable.new
             fakeBankAccounts = Array.new(2) { BankAccount.new }
 
-            DATE_FILTER  = { gt: "2020-01-01", lt: "2020-01-31T12" };
+            dateFilter  = { gt: "2020-01-01", lt: "2020-01-31T12" };
             fakeBankAccounts[0].id = "bank_fakeId"
             allow(bankAccountApi).to receive(:list) { fakeBankAccounts }
-            response = bankAccountApi.list(date_created: DATE_FILTER)
+            response = bankAccountApi.list(date_created: dateFilter)
 
             expect(response.length()).to eq(2)
             expect(bankAccountApi.list).to eq(fakeBankAccounts)
@@ -171,10 +171,10 @@ RSpec.describe "BankAccountsApi" do
             bankAccountWritable = BankAccountWritable.new
             fakeBankAccounts = Array.new(2) { BankAccount.new }
 
-            METADATA  = { fakeMetadata: "fakemetadata" }
+            metadata  = { fakeMetadata: "fakemetadata" }
             fakeBankAccounts[0].id = "bank_fakeId"
             allow(bankAccountApi).to receive(:list) { fakeBankAccounts }
-            response = bankAccountApi.list(metadata: METADATA)
+            response = bankAccountApi.list(metadata: metadata)
 
             expect(response.length()).to eq(2)
             expect(bankAccountApi.list).to eq(fakeBankAccounts)

--- a/lib/openapi_client/models/bank_account.rb
+++ b/lib/openapi_client/models/bank_account.rb
@@ -1,7 +1,7 @@
 =begin
 #Lob
 
-#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
 
 The version of the OpenAPI document: 1.3.0
 Contact: lob-openapi@lob.com
@@ -15,7 +15,7 @@ require 'time'
 
 module Lob
   class BankAccount
-    # An internal description that identifies this resource. Must be no longer than 255 characters. 
+    # An internal description that identifies this resource. Must be no longer than 255 characters.
     attr_accessor :description
 
     # Must be a [valid US routing number](https://www.frbservices.org/index.html).
@@ -257,7 +257,7 @@ module Lob
         invalid_properties.push("invalid value for \"id\", must conform to the pattern #{pattern}.")
       end
 
-      pattern = Regexp.new(/^https:\/\/lob-assets\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/lob-assets\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !@signature_url.nil? && @signature_url !~ pattern
         invalid_properties.push("invalid value for \"signature_url\", must conform to the pattern #{pattern}.")
       end
@@ -293,7 +293,7 @@ module Lob
       return false if @signatory.to_s.length > 30
       return false if @id.nil?
       return false if @id !~ Regexp.new(/^bank_[a-zA-Z0-9]+$/)
-      return false if !@signature_url.nil? && @signature_url !~ Regexp.new(/^https:\/\/lob-assets\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      return false if !@signature_url.nil? && @signature_url !~ Regexp.new(/^https:\/\/lob-assets\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       return false if @date_created.nil?
       return false if @date_modified.nil?
       return false if @object.nil?
@@ -392,7 +392,7 @@ module Lob
     # Custom attribute writer method with validation
     # @param [Object] signature_url Value to be assigned
     def signature_url=(signature_url)
-      pattern = Regexp.new(/^https:\/\/lob-assets\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/lob-assets\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !signature_url.nil? && signature_url !~ pattern
         fail ArgumentError, "invalid value for \"signature_url\", must conform to the pattern #{pattern}."
       end

--- a/lib/openapi_client/models/check.rb
+++ b/lib/openapi_client/models/check.rb
@@ -1,7 +1,7 @@
 =begin
 #Lob
 
-#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
 
 The version of the OpenAPI document: 1.3.0
 Contact: lob-openapi@lob.com
@@ -22,7 +22,7 @@ module Lob
 
     attr_accessor :from
 
-    # An internal description that identifies this resource. Must be no longer than 255 characters. 
+    # An internal description that identifies this resource. Must be no longer than 255 characters.
     attr_accessor :description
 
     # Use metadata to store custom information for tagging and labeling back to your internal systems. Must be an object with up to 20 key-value pairs. Keys must be at most 40 characters and values must be at most 500 characters. Neither can contain the characters `\"` and `\\`. i.e. '{\"customer_id\" : \"NEWYORK2015\"}' Nested objects are not supported.  See [Metadata](#section/Metadata) for more information.
@@ -402,7 +402,7 @@ module Lob
         invalid_properties.push('invalid value for "url", url cannot be nil.')
       end
 
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if @url !~ pattern
         invalid_properties.push("invalid value for \"url\", must conform to the pattern #{pattern}.")
       end
@@ -447,7 +447,7 @@ module Lob
       return false if !@check_bottom_template_version_id.nil? && @check_bottom_template_version_id !~ Regexp.new(/^vrsn_[a-zA-Z0-9]+$/)
       return false if !@attachment_template_version_id.nil? && @attachment_template_version_id !~ Regexp.new(/^vrsn_[a-zA-Z0-9]+$/)
       return false if @url.nil?
-      return false if @url !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      return false if @url !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       return false if @carrier.nil?
       carrier_validator = EnumAttributeValidator.new('String', ["USPS"])
       return false unless carrier_validator.valid?(@carrier)
@@ -605,7 +605,7 @@ module Lob
         fail ArgumentError, 'url cannot be nil'
       end
 
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if url !~ pattern
         fail ArgumentError, "invalid value for \"url\", must conform to the pattern #{pattern}."
       end

--- a/lib/openapi_client/models/letter.rb
+++ b/lib/openapi_client/models/letter.rb
@@ -1,7 +1,7 @@
 =begin
 #Lob
 
-#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
 
 The version of the OpenAPI document: 1.3.0
 Contact: lob-openapi@lob.com
@@ -49,7 +49,7 @@ module Lob
 
     attr_accessor :object
 
-    # An internal description that identifies this resource. Must be no longer than 255 characters. 
+    # An internal description that identifies this resource. Must be no longer than 255 characters.
     attr_accessor :description
 
     # Use metadata to store custom information for tagging and labeling back to your internal systems. Must be an object with up to 20 key-value pairs. Keys must be at most 40 characters and values must be at most 500 characters. Neither can contain the characters `\"` and `\\`. i.e. '{\"customer_id\" : \"NEWYORK2015\"}' Nested objects are not supported.  See [Metadata](#section/Metadata) for more information.
@@ -81,7 +81,7 @@ module Lob
     # Set this attribute to `true` for double sided printing, or `false` for for single sided printing. Defaults to `true`.
     attr_accessor :double_sided
 
-    # Specifies the location of the address information that will show through the double-window envelope. 
+    # Specifies the location of the address information that will show through the double-window envelope.
     attr_accessor :address_placement
 
     attr_accessor :return_envelope
@@ -401,7 +401,7 @@ module Lob
         invalid_properties.push("invalid value for \"template_version_id\", must conform to the pattern #{pattern}.")
       end
 
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !@url.nil? && @url !~ pattern
         invalid_properties.push("invalid value for \"url\", must conform to the pattern #{pattern}.")
       end
@@ -434,7 +434,7 @@ module Lob
       return false if @id !~ Regexp.new(/^ltr_[a-zA-Z0-9]+$/)
       return false if !@template_id.nil? && @template_id !~ Regexp.new(/^tmpl_[a-zA-Z0-9]+$/)
       return false if !@template_version_id.nil? && @template_version_id !~ Regexp.new(/^vrsn_[a-zA-Z0-9]+$/)
-      return false if !@url.nil? && @url !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      return false if !@url.nil? && @url !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       return false if @object.nil?
       object_validator = EnumAttributeValidator.new('String', ["letter"])
       return false unless object_validator.valid?(@object)
@@ -495,7 +495,7 @@ module Lob
     # Custom attribute writer method with validation
     # @param [Object] url Value to be assigned
     def url=(url)
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !url.nil? && url !~ pattern
         fail ArgumentError, "invalid value for \"url\", must conform to the pattern #{pattern}."
       end

--- a/lib/openapi_client/models/postcard.rb
+++ b/lib/openapi_client/models/postcard.rb
@@ -1,7 +1,7 @@
 =begin
 #Lob
 
-#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
 
 The version of the OpenAPI document: 1.3.0
 Contact: lob-openapi@lob.com
@@ -60,7 +60,7 @@ module Lob
     # A [signed link](#section/Asset-URLs) served over HTTPS. The link returned will expire in 30 days to prevent mis-sharing. Each time a GET request is initiated, a new signed URL will be generated.
     attr_accessor :url
 
-    # An internal description that identifies this resource. Must be no longer than 255 characters. 
+    # An internal description that identifies this resource. Must be no longer than 255 characters.
     attr_accessor :description
 
     # Use metadata to store custom information for tagging and labeling back to your internal systems. Must be an object with up to 20 key-value pairs. Keys must be at most 40 characters and values must be at most 500 characters. Neither can contain the characters `\"` and `\\`. i.e. '{\"customer_id\" : \"NEWYORK2015\"}' Nested objects are not supported.  See [Metadata](#section/Metadata) for more information.
@@ -334,7 +334,7 @@ module Lob
         invalid_properties.push('invalid value for "url", url cannot be nil.')
       end
 
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if @url !~ pattern
         invalid_properties.push("invalid value for \"url\", must conform to the pattern #{pattern}.")
       end
@@ -360,7 +360,7 @@ module Lob
       object_validator = EnumAttributeValidator.new('String', ["postcard"])
       return false unless object_validator.valid?(@object)
       return false if @url.nil?
-      return false if @url !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      return false if @url !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       return false if !@description.nil? && @description.to_s.length > 255
       true
     end
@@ -451,7 +451,7 @@ module Lob
         fail ArgumentError, 'url cannot be nil'
       end
 
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if url !~ pattern
         fail ArgumentError, "invalid value for \"url\", must conform to the pattern #{pattern}."
       end

--- a/lib/openapi_client/models/self_mailer.rb
+++ b/lib/openapi_client/models/self_mailer.rb
@@ -1,7 +1,7 @@
 =begin
 #Lob
 
-#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
 
 The version of the OpenAPI document: 1.3.0
 Contact: lob-openapi@lob.com
@@ -24,7 +24,7 @@ module Lob
 
     attr_accessor :size
 
-    # An internal description that identifies this resource. Must be no longer than 255 characters. 
+    # An internal description that identifies this resource. Must be no longer than 255 characters.
     attr_accessor :description
 
     # Use metadata to store custom information for tagging and labeling back to your internal systems. Must be an object with up to 20 key-value pairs. Keys must be at most 40 characters and values must be at most 500 characters. Neither can contain the characters `\"` and `\\`. i.e. '{\"customer_id\" : \"NEWYORK2015\"}' Nested objects are not supported.  See [Metadata](#section/Metadata) for more information.
@@ -284,7 +284,7 @@ module Lob
         invalid_properties.push('invalid value for "url", url cannot be nil.')
       end
 
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if @url !~ pattern
         invalid_properties.push("invalid value for \"url\", must conform to the pattern #{pattern}.")
       end
@@ -305,7 +305,7 @@ module Lob
       object_validator = EnumAttributeValidator.new('String', ["self_mailer"])
       return false unless object_validator.valid?(@object)
       return false if @url.nil?
-      return false if @url !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      return false if @url !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       true
     end
 
@@ -407,7 +407,7 @@ module Lob
         fail ArgumentError, 'url cannot be nil'
       end
 
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if url !~ pattern
         fail ArgumentError, "invalid value for \"url\", must conform to the pattern #{pattern}."
       end

--- a/lib/openapi_client/models/thumbnail.rb
+++ b/lib/openapi_client/models/thumbnail.rb
@@ -1,7 +1,7 @@
 =begin
 #Lob
 
-#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
 
 The version of the OpenAPI document: 1.3.0
 Contact: lob-openapi@lob.com
@@ -85,17 +85,17 @@ module Lob
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !@small.nil? && @small !~ pattern
         invalid_properties.push("invalid value for \"small\", must conform to the pattern #{pattern}.")
       end
 
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !@medium.nil? && @medium !~ pattern
         invalid_properties.push("invalid value for \"medium\", must conform to the pattern #{pattern}.")
       end
 
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !@large.nil? && @large !~ pattern
         invalid_properties.push("invalid value for \"large\", must conform to the pattern #{pattern}.")
       end
@@ -106,16 +106,16 @@ module Lob
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      return false if !@small.nil? && @small !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
-      return false if !@medium.nil? && @medium !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
-      return false if !@large.nil? && @large !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      return false if !@small.nil? && @small !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
+      return false if !@medium.nil? && @medium !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
+      return false if !@large.nil? && @large !~ Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       true
     end
 
     # Custom attribute writer method with validation
     # @param [Object] small Value to be assigned
     def small=(small)
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !small.nil? && small !~ pattern
         fail ArgumentError, "invalid value for \"small\", must conform to the pattern #{pattern}."
       end
@@ -126,7 +126,7 @@ module Lob
     # Custom attribute writer method with validation
     # @param [Object] medium Value to be assigned
     def medium=(medium)
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !medium.nil? && medium !~ pattern
         fail ArgumentError, "invalid value for \"medium\", must conform to the pattern #{pattern}."
       end
@@ -137,7 +137,7 @@ module Lob
     # Custom attribute writer method with validation
     # @param [Object] large Value to be assigned
     def large=(large)
-      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+$/)
+      pattern = Regexp.new(/^https:\/\/(lob-assets|lob-assets-staging)\.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(\.pdf|_thumb_[a-z]+_[0-9]+\.png)\?(version=[a-z0-9-]*&)?expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+$/)
       if !large.nil? && large !~ pattern
         fail ArgumentError, "invalid value for \"large\", must conform to the pattern #{pattern}."
       end


### PR DESCRIPTION
In reference to [this issue](https://github.com/lob/lob-ruby/issues/209).