### PR TITLE
Add "contract" as a valid carrier_route_type

### DIFF
--- a/lib/openapi_client/models/dpv_footnote.rb
+++ b/lib/openapi_client/models/dpv_footnote.rb
@@ -32,6 +32,7 @@ module Lob
     R1 = "R1".freeze
     R7 = "R7".freeze
     RR = "RR".freeze
+    TA = "TA".freeze
 
     # Builds the enum from string
     # @param [String] The enum value in the form of the string

--- a/lib/openapi_client/models/dpv_footnote.rb
+++ b/lib/openapi_client/models/dpv_footnote.rb
@@ -1,7 +1,7 @@
 =begin
 #Lob
 
-#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
 
 The version of the OpenAPI document: 1.3.0
 Contact: lob-openapi@lob.com
@@ -19,6 +19,7 @@ module Lob
     A1 = "A1".freeze
     BB = "BB".freeze
     CC = "CC".freeze
+    C1 = "C1".freeze
     N1 = "N1".freeze
     F1 = "F1".freeze
     G1 = "G1".freeze

--- a/lib/openapi_client/models/dpv_footnote.rb
+++ b/lib/openapi_client/models/dpv_footnote.rb
@@ -26,6 +26,7 @@ module Lob
     U1 = "U1".freeze
     M1 = "M1".freeze
     M3 = "M3".freeze
+    PB = "PB".freeze
     P1 = "P1".freeze
     P3 = "P3".freeze
     R1 = "R1".freeze

--- a/lib/openapi_client/models/us_components.rb
+++ b/lib/openapi_client/models/us_components.rb
@@ -470,7 +470,7 @@ module Lob
       return false if @county_fips.nil?
       return false if @carrier_route.nil?
       return false if @carrier_route_type.nil?
-      carrier_route_type_validator = EnumAttributeValidator.new('String', ["city_delivery", "rural_route", "highway_contract", "po_box", "general_delivery", ""])
+      carrier_route_type_validator = EnumAttributeValidator.new('String', ["city_delivery", "rural_route", "highway_contract", "po_box", "general_delivery", "contract", ""])
       return false unless carrier_route_type_validator.valid?(@carrier_route_type)
       true
     end
@@ -576,7 +576,7 @@ module Lob
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] carrier_route_type Object to be assigned
     def carrier_route_type=(carrier_route_type)
-      validator = EnumAttributeValidator.new('String', ["city_delivery", "rural_route", "highway_contract", "po_box", "general_delivery", ""])
+      validator = EnumAttributeValidator.new('String', ["city_delivery", "rural_route", "highway_contract", "po_box", "general_delivery", "contract", ""])
       unless validator.valid?(carrier_route_type)
         fail ArgumentError, "invalid value for \"carrier_route_type\", must be one of #{validator.allowable_values}."
       end


### PR DESCRIPTION
I came across an error when trying to validate a certain US address where I was getting back a carrier_route_type that wasn't in the allowed list, but I verified that it was correct using the API testing tool in lob.com itself.

Adding "contract" to the list of allowed carrier_route_type's solves the issue 👍

<img width="1039" alt="Screenshot 2023-05-16 at 01 19 31" src="https://github.com/lob/lob-ruby/assets/12945617/2363b40b-8644-464c-ba95-7601efa75c29">

<img width="604" alt="Screenshot 2023-05-16 at 01 19 15" src="https://github.com/lob/lob-ruby/assets/12945617/10ebbcf3-036e-4b74-87c4-959fb3107f18">
