### PR TITLE
Fix letter class to check if object is a string before matching

### DIFF
--- a/lib/openapi_client/models/letter.rb
+++ b/lib/openapi_client/models/letter.rb
@@ -621,7 +621,7 @@ module Lob
       self.class.openapi_types.each_pair do |key, type|
         if attributes[self.class.attribute_map[key]].nil? && self.class.openapi_nullable.include?(key)
           self.send("#{key}=", nil) # // guardrails-disable-line
-        elsif type =~ /\AArray<(.*)>/i
+        elsif type.kind_of?(String) && type =~ /\AArray<(.*)>/i
           # check to ensure the input is an array given that the attribute
           # is documented as an array but the input is not
           if attributes[self.class.attribute_map[key]].is_a?(Array)


### PR DESCRIPTION
Hi there,
I'm trying to update a Ruby on Rails app to Ruby 3.2 and we hit an error with one of our specs using the lob-ruby sdk. 

The error was:
```
     NoMethodError:
       undefined method `=~' for [:ReturnEnvelope, :Boolean]:Array
     # /usr/local/bundle/gems/lob-6.0.2/lib/openapi_client/models/letter.rb:624:in `block in build_from_hash'
     # /usr/local/bundle/gems/lob-6.0.2/lib/openapi_client/models/letter.rb:621:in `each_pair'
     # /usr/local/bundle/gems/lob-6.0.2/lib/openapi_client/models/letter.rb:621:in `build_from_hash'
     # /usr/local/bundle/gems/lob-6.0.2/lib/openapi_client/models/letter.rb:612:in `build_from_hash'
     # /usr/local/bundle/gems/lob-6.0.2/lib/openapi_client/api_client.rb:282:in `convert_to_type'
     # /usr/local/bundle/gems/lob-6.0.2/lib/openapi_client/api_client.rb:242:in `deserialize'
     # /usr/local/bundle/gems/lob-6.0.2/lib/openapi_client/api_client.rb:73:in `call_api'
     # /usr/local/bundle/gems/lob-6.0.2/lib/openapi_client/api/letters_api.rb:158:in `letter_create_with_http_info'
     # /usr/local/bundle/gems/lob-6.0.2/lib/openapi_client/api/letters_api.rb:97:in `create'
```

In Ruby 3.2, they removed a deprecated method `=~` on Object. 
https://rubyreferences.github.io/rubychanges/3.2.html#removals

This seemed to fix it locally. I'm not sure what your standards are for this gem so this is the minimum change. Let me know what else you need for this to be merged. Thank you!