### PR TITLE
Fix regex warning in bank_account.rb

### DIFF
--- a/lib/openapi_client/models/bank_account.rb
+++ b/lib/openapi_client/models/bank_account.rb
@@ -1,7 +1,7 @@
 =begin
 #Lob
 
-#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
 
 The version of the OpenAPI document: 1.3.0
 Contact: lob-openapi@lob.com
@@ -15,7 +15,7 @@ require 'time'
 
 module Lob
   class BankAccount
-    # An internal description that identifies this resource. Must be no longer than 255 characters. 
+    # An internal description that identifies this resource. Must be no longer than 255 characters.
     attr_accessor :description
 
     # Must be a [valid US routing number](https://www.frbservices.org/index.html).
@@ -257,7 +257,7 @@ module Lob
         invalid_properties.push("invalid value for \"id\", must conform to the pattern #{pattern}.")
       end
 
-      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+/)
+      pattern = lob_assets_url_regex
       if !@signature_url.nil? && @signature_url !~ pattern
         invalid_properties.push("invalid value for \"signature_url\", must conform to the pattern #{pattern}.")
       end
@@ -293,7 +293,7 @@ module Lob
       return false if @signatory.to_s.length > 30
       return false if @id.nil?
       return false if @id !~ Regexp.new(/^bank_[a-zA-Z0-9]+$/)
-      return false if !@signature_url.nil? && @signature_url !~ Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+/)
+      return false if !@signature_url.nil? && @signature_url !~ lob_assets_url_regex
       return false if @date_created.nil?
       return false if @date_modified.nil?
       return false if @object.nil?
@@ -392,7 +392,7 @@ module Lob
     # Custom attribute writer method with validation
     # @param [Object] signature_url Value to be assigned
     def signature_url=(signature_url)
-      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+/)
+      pattern = lob_assets_url_regex
       if !signature_url.nil? && signature_url !~ pattern
         fail ArgumentError, "invalid value for \"signature_url\", must conform to the pattern #{pattern}."
       end
@@ -569,6 +569,10 @@ module Lob
       else
         value
       end
+    end
+
+    def lob_assets_url_regex
+      Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9\-_]+/)
     end
 
   end


### PR DESCRIPTION
Hi! 

I'm getting this error when including this gem in my Rails project. 

`/Users/arich/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/lob-ruby/lib/openapi_client/models/bank_account.rb: warning: character class has '-' without escape`

Most of the changes here are just consolidating the multiple definitions of the same long regex to a single method. I can undo that if it's not helpful.

The change in detail:
Before: 
`[a-zA-Z0-9-_]+/`

After:
`[a-zA-Z0-9\-_]+/`

We're just escaping the `-` as a character you want to include in this regex. 

![image](https://github.com/lob/lob-ruby/assets/852709/b6b4506b-7ac4-4ff1-b861-75540a7f7e56)
