### PR TITLE
fix: Escape `-` in Regexp ranges

### DIFF
--- a/lib/openapi_client/models/bank_account.rb
+++ b/lib/openapi_client/models/bank_account.rb
@@ -257,7 +257,7 @@ module Lob
         invalid_properties.push("invalid value for \"id\", must conform to the pattern #{pattern}.")
       end
 
-      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+/)
+      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9\-_]+/)
       if !@signature_url.nil? && @signature_url !~ pattern
         invalid_properties.push("invalid value for \"signature_url\", must conform to the pattern #{pattern}.")
       end
@@ -293,7 +293,7 @@ module Lob
       return false if @signatory.to_s.length > 30
       return false if @id.nil?
       return false if @id !~ Regexp.new(/^bank_[a-zA-Z0-9]+$/)
-      return false if !@signature_url.nil? && @signature_url !~ Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+/)
+      return false if !@signature_url.nil? && @signature_url !~ Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9\-_]+/)
       return false if @date_created.nil?
       return false if @date_modified.nil?
       return false if @object.nil?
@@ -392,7 +392,7 @@ module Lob
     # Custom attribute writer method with validation
     # @param [Object] signature_url Value to be assigned
     def signature_url=(signature_url)
-      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+/)
+      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9\-_]+/)
       if !signature_url.nil? && signature_url !~ pattern
         fail ArgumentError, "invalid value for \"signature_url\", must conform to the pattern #{pattern}."
       end

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -17,34 +17,34 @@ describe Lob::ApiClient do
     context 'URL stuff' do
       context 'host' do
         it 'removes http from host' do
-          Lob.configure { |c| c.host = 'http://example.com' }
+          Lob::Configuration.default.host = 'http://example.com'
           expect(Lob::Configuration.default.host).to eq('example.com')
         end
 
         it 'removes https from host' do
-          Lob.configure { |c| c.host = 'https://wookiee.com' }
+          Lob::Configuration.default.host = 'https://wookiee.com'
           expect(Lob::ApiClient.default.config.host).to eq('wookiee.com')
         end
 
         it 'removes trailing path from host' do
-          Lob.configure { |c| c.host = 'hobo.com/v4' }
+          Lob::Configuration.default.host = 'hobo.com/v4'
           expect(Lob::Configuration.default.host).to eq('hobo.com')
         end
       end
 
       context 'base_path' do
         it "prepends a slash to base_path" do
-          Lob.configure { |c| c.base_path = 'v4/dog' }
+          Lob::Configuration.default.base_path = 'v4/dog'
           expect(Lob::Configuration.default.base_path).to eq('/v4/dog')
         end
 
         it "doesn't prepend a slash if one is already there" do
-          Lob.configure { |c| c.base_path = '/v4/dog' }
+          Lob::Configuration.default.base_path = '/v4/dog'
           expect(Lob::Configuration.default.base_path).to eq('/v4/dog')
         end
 
         it "ends up as a blank string if nil" do
-          Lob.configure { |c| c.base_path = nil }
+          Lob::Configuration.default.base_path = nil
           expect(Lob::Configuration.default.base_path).to eq('')
         end
       end


### PR DESCRIPTION
Bootsnap warns if it sees confusing regexp range like `[a-b-_]`. In general, it's better to escape dash in regexp ranges when it's supposed to mean literal dash.

This patch fixes warnings (when [bootsnap](https://github.com/Shopify/bootsnap) is active):

```
/home/ixti/.gem/ruby/3.0.6/gems/lob-6.0.5/lib/openapi_client/models/bank_account.rb:260: warning: character class has '-' without escape
/home/ixti/.gem/ruby/3.0.6/gems/lob-6.0.5/lib/openapi_client/models/bank_account.rb:296: warning: character class has '-' without escape
/home/ixti/.gem/ruby/3.0.6/gems/lob-6.0.5/lib/openapi_client/models/bank_account.rb:395: warning: character class has '-' without escape
/home/ixti/.gem/ruby/3.0.6/gems/bootsnap-1.17.1/lib/bootsnap/compile_cache/iseq.rb:53: warning: character class has '-' without escape
/home/ixti/.gem/ruby/3.0.6/gems/bootsnap-1.17.1/lib/bootsnap/compile_cache/iseq.rb:53: warning: character class has '-' without escape
/home/ixti/.gem/ruby/3.0.6/gems/bootsnap-1.17.1/lib/bootsnap/compile_cache/iseq.rb:53: warning: character class has '-' without escape
```

Related-PR: https://github.com/lob/lob-ruby/pull/225