### PR TITLE
PLAT-2193: update deprecated GitHub Actions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         ruby-version: ["3.0", "3.1"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/update_gem.yml
+++ b/.github/workflows/update_gem.yml
@@ -8,7 +8,7 @@ jobs:
   publish_gem:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## JIRA

* [PLAT-2193](https://lobsters.atlassian.net/browse/PLAT-2193)

## Description

* `actions/checkout@v3` and `actions/checkout@v2` run Node 12 or 16 and are deprecated, we need them to run Node 20:

See:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
and
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

---

![image](https://github.com/lob/lob-ruby/assets/117756379/7356b0c0-2354-47e9-91f8-2e2d4df20de3)

[PLAT-2193]: https://lobsters.atlassian.net/browse/PLAT-2193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ